### PR TITLE
Magic Dots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.0.1"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 DiffRules = "1"
+EllipsisNotation = "0.4"
 Requires = "1"
 julia = "1.3"
 

--- a/src/Tullio.jl
+++ b/src/Tullio.jl
@@ -1,5 +1,8 @@
 module Tullio
 
+using EllipsisNotation: (..)
+using Base.Broadcast: newindex, newindexer, combine_axes # , check_broadcast_axes
+
 #========== ⚜️ ==========#
 
 export @tullio

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -38,6 +38,8 @@ Then it divides up the other axes, each accumulating in its own copy of `Z`.
 `keep=nothing` means that it overwrites the array, anything else (`keep=true`) adds on.
 """
 function threader(fun!::Function, T::Type, Z::AbstractArray, As::Tuple, I0s::Tuple, J0s::Tuple; block, keep=nothing)
+    return fun!(T, Z, As..., I0s..., J0s..., keep)
+    # not yet fixed up for broadcasting
     Is = map(UnitRange, I0s)
     Js = map(UnitRange, J0s)
     if isnothing(block)

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -161,6 +161,34 @@ end
 
 end
 
+@testset "broadcasting" begin
+
+    f1(A) = @tullio C[i, ..] := A[i, ..] + 1
+    @test f1(ones(3)) == ones(3) .+ 1
+    @test f1(ones(3,4)) == ones(3,4) .+ 1
+    @test f1(ones(3,4,5)) == ones(3,4,5) .+ 1
+
+    f2(A) = @tullio C[i, ..] := A[i, k, ..]
+    @test f2(ones(3,4)) == fill(4.0, 3)
+    A3 = rand(3,4,5)
+    @test f2(A3) ≈ dropdims(sum(A3, dims=2), dims=2)
+
+    f3(A, B) = @tullio C[i,j, ..] := A[i, k, ..] * B[j, k, ..]
+    A2 = rand(3,3);
+    B2 = rand(3,3);
+    @test f3(A2, B2) ≈ A2 * B2'
+    A3 = rand(3,3,2);
+    B3 = rand(3,3,2);
+    C3 = f3(A3, B3)
+    @test C3[:,:,1] ≈ A3[:,:,1] * B3[:,:,1]'
+    @test C3[:,:,2] ≈ A3[:,:,2] * B3[:,:,2]'
+
+    C4 = f3(A3, B2)
+    @test C4[:,:,1] ≈ A3[:,:,1] * B2[:,:]'
+    @test C4[:,:,2] ≈ A3[:,:,2] * B2[:,:]'
+
+end
+
 @testset "without packages" begin
 
     A = [i^2 for i in 1:10]


### PR DESCRIPTION
Sometimes it would be neat if the same function could allow for several dimensionalities. Perhaps this is written:
```julia
f(A, B) = @tullio C[i, j, ..] := A[i, k, ..] * B[k, j, ..]
```
which accepts `f(Matrix, Matrix)::Matrix` as usual, but also `f(Array3, Array3)::Array3` with one more dimension. And ideally also `f(Array4, Matrix)::Array4` with varying numbers of dimensions, obeying broadcasting rules.

This is an implementation which adds extra loops over one `CartesianIndex{N}`, using clever things from `Base.Broadcast` to work out the appropriate ranges. It adds a bit more complication than I pictured before starting!

First working version. Multi-threading is disabled, no idea whether gradients will work.  
