### PR TITLE
Allow threader to inline by making keyword args positional

### DIFF
--- a/src/threads.jl
+++ b/src/threads.jl
@@ -37,7 +37,7 @@ Then it divides up the other axes, each accumulating in its own copy of `Z`.
 
 `keep=nothing` means that it overwrites the array, anything else (`keep=true`) adds on.
 """
-function threader(fun!::Function, T::Type, Z::AbstractArray, As::Tuple, I0s::Tuple, J0s::Tuple; block, keep=nothing)
+@inline function threader(fun!::Function, T::Type, Z::AbstractArray, As::Tuple, I0s::Tuple, J0s::Tuple, block, keep=nothing)
     if !all(r -> r isa AbstractUnitRange, I0s) || !all(r -> r isa AbstractUnitRange, J0s)
         fun!(T, Z, As..., I0s..., J0s..., keep) # don't thread ranges like 10:-1:1
         return nothing
@@ -66,7 +66,7 @@ to all output arrays. If there are none, then it takes a second strategy
 of dividing up the other ranges into blocks disjoint in every index,
 and giving those to different threads.
 """
-function ∇threader(fun!::Function, T::Type, As::Tuple, I0s::Tuple, J0s::Tuple; block)
+function ∇threader(fun!::Function, T::Type, As::Tuple, I0s::Tuple, J0s::Tuple, block)
     Is = map(UnitRange, I0s)
     Js = map(UnitRange, J0s)
     if isnothing(block)


### PR DESCRIPTION
and marking it `@inline`; removes allocations in non-threaded cases.
```julia
julia> using LoopVectorization, Einsum, Tullio

julia> M, N, J, K = 143, 149, 15, 13
(143, 149, 15, 13)

julia> A = rand(M, J, K);

julia> B = rand(K, N, J);

julia> C₁ = Array{Float64}(undef, M, N); C₂ = similar(C₁); C₃ = similar(C₁);

julia> einmul!(C, A, B) = @einsum C[m,n] = A[m,j,k] * B[k,n,j];

julia> tulliomul!(C, A, B) = @tullio C[m,n] = A[m,j,k] * B[k,n,j] threads=false;

julia> function tmul!(C, A, B)
           @avx for n ∈ axes(C,2), m ∈ axes(C,1)
               Cₘₙ = zero(eltype(C))
               for j ∈ axes(A,2), k ∈ axes(A,3)
                   Cₘₙ += A[m,j,k] * B[k,n,j]
               end
               C[m,n] = Cₘₙ
           end
       end
tmul! (generic function with 1 method)

julia> @btime tmul!($C₁, $A, $B);
  90.071 μs (0 allocations: 0 bytes)

julia> @btime einmul!($C₂, $A, $B);
  3.379 ms (0 allocations: 0 bytes)

julia> @btime tulliomul!($C₃, $A, $B);
  90.613 μs (7 allocations: 224 bytes)

julia> C₁ ≈ C₂ ≈ C₃
true
```
After
```julia
julia> @btime tulliomul!($C₃, $A, $B);
  88.226 μs (0 allocations: 0 bytes)
```
I think it's preferable to have 0-overhead over using LoopVectorization directly.
It didn't really have much impact on performance in this case (overhead is relatively small), but I just like seeing `0 allocations: 0 bytes` when possible on principle.