### PR TITLE
Slightly better multi-threading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tullio"
 uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 authors = ["Michael Abbott"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -733,6 +733,7 @@ function action_functions(store)
             tuple($(axisleft...),), tuple($(axisred...),), $(store.redfun), $block, $keep)
         $(store.leftarray)
     end)
+    store.verbose>0 && block != nothing && @info "threading threshold (from cost = $(store.cost))" block
 
     if :newarray in store.flags
         # then slurp up outex to make a function:

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -109,14 +109,14 @@ and giving those to different threads. But this was only right for 2 indices,
 and is now disabled.
 """
 function ∇threader(fun!::Function, T::Type, As::Tuple, I0s::Tuple, J0s::Tuple, block)
+
     Is = map(UnitRange, I0s)
     Js = map(UnitRange, J0s)
-
-    spawns, blocks = threadlog2s(Is, Js, block)
 
     if isnothing(block) || (spawns<1 && blocks<1)
         fun!(T, As..., Is..., Js...)
     else
+        spawns, blocks = threadlog2s(Is, Js, block)
         thread_halves(fun!, T, As, Is, Js, Val(spawns), Val(blocks))
     end
 

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -1,7 +1,7 @@
 
 #========== cost "model" ==========#
 
-const BLOCK = Ref(2^19)
+const BLOCK = Ref(2^18)
 # matmul: crossover about 70x70 on my laptop, 70^3 = 343_000, log2(70^3) = 18.3, but only 30% effect at 100^3=10^6
 # batchmul: crossover between 20 & 30, log2(20^4) == 17.3, log2(30^4) == 19.6
 # contract01: 1500 * 100, length 15_000, doesn't want threading

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -74,7 +74,12 @@ Then it divides up the other axes, each accumulating in its own copy of `Z`.
         ) - max(0,spawns)
     # @info "threader" spawns blocks
 
-    _threader(fun!, T, Z, As, Is, Js, Val(spawns), Val(blocks), keep)
+    if blocks<1 && spawns<1 # then skip all the Val() stuff
+        fun!(T, Z, As..., Is..., Js..., keep)
+    else
+        _threader(fun!, T, Z, As, Is, Js, Val(spawns), Val(blocks), keep)
+    end
+    nothing
 end
 function _threader(fun!, T, Z, As, Is, Js, Val_spawns, Val_blocks, keep)
     if length(Is) >= 1
@@ -86,7 +91,7 @@ function _threader(fun!, T, Z, As, Is, Js, Val_spawns, Val_blocks, keep)
     else
         fun!(T, Z, As..., Is..., Js..., keep)
     end
-    return nothing
+    nothing
 end
 
 """

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -72,8 +72,8 @@ Then it divides up the other axes, each accumulating in its own copy of `Z`.
         thread_scalar(fun!, T, Z, As, Js, redfun, scalar_spawns, keep)
     elseif breaks>1
         # Val_breaks = Val(breaks)
-        # tile_halves(fun!, T, As, Is, Js, Val_breaks, keep)
-        tile_halves(fun!, T, As, Is, Js, breaks, keep)
+        # tile_halves(fun!, T, (Z, As...), Is, Js, Val_breaks, keep)
+        tile_halves(fun!, T, (Z, As...), Is, Js, breaks, keep)
     else
         fun!(T, Z, As..., Is..., Js..., keep)
     end

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -23,7 +23,7 @@ const COSTS = Dict(:+ => 0, :- => 0, :* => 0,
 
 callcost(sy, store) = store.cost += get(COSTS, sy, 10)
 
-const TILE = Ref(64^3) # 2x quicker matmul at size 1000
+const TILE = Ref(128^3)
 
 #========== runtime functions ==========#
 

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -46,12 +46,12 @@ Then it divides up the other axes, each accumulating in its own copy of `Z`.
 `keep=nothing` means that it overwrites the array, anything else (`keep=true`) adds on.
 """
 @inline function threader(fun!::Function, T::Type, Z::AbstractArray, As::Tuple, I0s::Tuple, J0s::Tuple, redfun, block, keep=nothing)
-
-    if isnothing(block) ||
-        # then threading is disabled
-        !all(r -> r isa AbstractUnitRange, I0s) || !all(r -> r isa AbstractUnitRange, J0s)
-        # don't thread ranges like 10:-1:1
+    if isnothing(block) # then threading is disabled
         fun!(T, Z, As..., I0s..., J0s..., keep)
+        return nothing
+    elseif !all(r -> r isa AbstractUnitRange, I0s) || !all(r -> r isa AbstractUnitRange, J0s)
+        # don't thread ranges like 10:-1:1, and disable @avx too
+        fun!(Array, Z, As..., I0s..., J0s..., keep)
         return nothing
     end
 
@@ -114,12 +114,12 @@ and giving those to different threads. But this was only right for 2 indices,
 and is now disabled.
 """
 function ∇threader(fun!::Function, T::Type, As::Tuple, I0s::Tuple, J0s::Tuple, block)
-
-    if isnothing(block) ||
-        # then threading is disabled
-        !all(r -> r isa AbstractUnitRange, I0s) || !all(r -> r isa AbstractUnitRange, J0s)
-        # don't thread ranges like 10:-1:1
+    if isnothing(block) # then threading is disabled
         fun!(T, As..., I0s..., J0s...)
+        return nothing
+    elseif !all(r -> r isa AbstractUnitRange, I0s) || !all(r -> r isa AbstractUnitRange, J0s)
+        # don't thread ranges like 10:-1:1, and disable @avx too
+        fun!(Array, As..., I0s..., J0s...)
         return nothing
     end
 

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -314,7 +314,6 @@ end
 @btime Tullio.cleave((1:13,))
 =#
 
-#=
 """
     quarter((1:10, 1:20, 3:4)) -> Q11, Q12, Q21, Q22
 Picks the longest two ranges, divides each in half, and returns the four quadrants.
@@ -359,7 +358,6 @@ function quarter(ranges::Tuple{Vararg{<:UnitRange,N}}, step::Int=4) where {N}
     end
     return Q11, Q12, Q21, Q22
 end
-=#
 
 #========== the end ==========#
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -362,7 +362,7 @@ end
     @test_throws Exception @eval @tullio s *= (max) A[i]
 
     # scalar + threading
-    L = randn(100 * Tullio.MINIBLOCK[]);
+    L = randn(100 * Tullio.TILE[]);
     @tullio (max) m := L[i]
     @test m == maximum(L)
 
@@ -385,12 +385,12 @@ end
     @test A ≈ @tullio A2[i] := A[i]^2 |> sqrt
     @test A ≈ @tullio (*) A2[i] := A[i]^2 |> sqrt
 
-    # larger size, to trigger threads & blocks
+    # larger size, to trigger threads & tiles
     C = randn(10^6) # > Tullio.BLOCK[]
     @tullio n2 = C[i]^2 |> sqrt
     @test n2 ≈ norm(C,2)
 
-    D = rand(1000, 1000) # > Tullio.MINIBLOCK[]
+    D = rand(1000, 1000) # > Tullio.TILE[]
     @tullio D2[_,j] := D[i,j]^2 |> sqrt
     @test D2 ≈ mapslices(norm, D, dims=1)
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -190,7 +190,9 @@ end
         j = mod(i^4, 1:10)
         A[j]
     end
-    @test B == A[[mod(i^4, 1:10) for i in 1:10]]
+    @test_skip B == A[[mod(i^4, 1:10) for i in 1:10]]
+    # on travis 1.3 multi-threaded, B == [500, 600, 100, 600, 500, 600, 100, 600, 100, 1000]
+    # and on 1.4 multi-threaded,    B == [100, 600, 100, 600, 100, 600, 100, 600, 100, 1000]
 
     # internal name leaks
     for sy in Tullio.SYMBOLS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ t1 = @elapsed using Tullio
 @info "Testing with $(Threads.nthreads()) threads"
 if Threads.nthreads() > 1 # use threading even on small arrays
     Tullio.BLOCK[] = 32
-    Tullio.MINIBLOCK[] = 32
+    Tullio.TILE[] = 32
 end
 
 #===== stuff =====#

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -79,20 +79,25 @@ using Tullio: range_expr_walk, divrange, minusrange, subranges, addranges
     end
 end
 
-using Tullio: cleave, quarter, productlength
+using Tullio: cleave, trisect, productlength
 
 @testset "threading" begin
     @test cleave((1:10, 1:4, 7:8)) == ((1:4, 1:4, 7:8), (5:10, 1:4, 7:8))
     @test cleave((7:8, 9:9)) == ((7:7, 9:9), (8:8, 9:9))
+    @test cleave((1:4,)) == ((1:2,), (3:4,))
+    @test cleave(()) == ((), ())
 
-    @test quarter((1:10, 11:20)) == ((1:4, 11:14), (1:4, 15:20), (5:10, 11:14), (5:10, 15:20))
-    @test sum(productlength, quarter((1:10, 11:20))) == 100
+    @test trisect((1:9, 11:12)) == ((1:3, 11:12), (4:6, 11:12), (7:9, 11:12))
+    @test trisect((1:9,)) == ((1:3,), (4:6,), (7:9,))
+    @test trisect(()) == ((), (), ())
+
+    @test sum(productlength, trisect((1:10, 11:20))) == 100
 
     for r1 in [1:10, 3:4, 5:5], r2 in [11:21, -3:-2, 0:0], r3 in [2:7, 8:9, 0:0]
         tup = (r1,r2,r3)
         len = productlength(tup)
         @test len == sum(productlength, cleave(tup))
-        @test len == sum(productlength, quarter(tup))
+        @test len == sum(productlength, trisect(tup))
     end
 end
 


### PR DESCRIPTION
This pre-computes the number of spawns to perform (and the number of recursive blocks) and then inlines everything. Improves times & allocations quite a bit. 

With the example of #15, but now `threads=true`, times on my laptop (Julia 1.4.2) were:
```
julia> tulliomul_multi!(C, A, B) = @tullio C[m,n] = A[m,j,k] * B[k,n,j];

julia> @btime tmul!($C₁, $A, $B);
  227.691 μs (0 allocations: 0 bytes)

julia> @btime einmul!($C₂, $A, $B);
  4.321 ms (0 allocations: 0 bytes)

julia> @btime tulliomul_multi!($C₃, $A, $B);
  137.678 μs (187 allocations: 10.00 KiB)

julia> C₁ ≈ C₂ ≈ C₃
true
```
and become:
```julia
julia> @btime tulliomul_multi!($C₃, $A, $B);
  120.737 μs (42 allocations: 3.14 KiB)
```

Simple matrix multiplication, before this change:
```
julia> using Tullio, LoopVectorization, LinearAlgebra

julia> N = 100; X = rand(N,N); Y = rand(N,N);

julia> mul(X, Y) = @tullio Z[i,k] := X[i,j] * Y[j,k];

julia> @btime mul($X, $Y);
  48.914 μs (49 allocations: 80.98 KiB)

julia> @btime *($X, $Y);
  44.157 μs (2 allocations: 78.20 KiB) # -> 24.138 μs (2 allocations: 78.20 KiB) with MKL

julia> BLAS.vendor()
:openblas64

julia> mul(X, Y) ≈ X * Y
true

julia> N = 1000; X = rand(N,N); Y = rand(N,N);

julia> @btime mul($X, $Y);
  27.212 ms (12386 allocations: 8.01 MiB)

julia> @btime *($X, $Y); 
  22.355 ms (2 allocations: 7.63 MiB) # -> 20.801 ms (2 allocations: 7.63 MiB) with MKL
```
after
```julia
julia> @btime mul($X, $Y);
  25.699 μs (48 allocations: 81.44 KiB)

julia> N = 1000; X = rand(N,N); Y = rand(N,N);

julia> @btime mul($X, $Y);
  23.812 ms (1572 allocations: 7.68 MiB)
```
Permuted-batched-mul example from the readme, before:
```
julia> using Tullio, LoopVectorization, NNlib, OMEinsum

julia> A′ = randn(20,30,500); B′ = randn(500,40,30);

julia> bmm_rev(A′, B′) = @tullio C[i,k,b] := A′[i,j,b] * B′[b,k,j] 

julia> bmm_rev(A′, B′) ≈ NNlib.batched_mul(A′, permutedims(B′, (3,2,1)))
true

julia> @btime bmm_rev($A′, $B′);
  663.462 μs (357 allocations: 3.07 MiB)

julia> @btime NNlib.batched_mul($A′, permutedims($B′, (3,2,1)));
  2.066 ms (4 allocations: 7.63 MiB)

julia> using OMEinsum # uses better permutedims() from TensorOperations

julia> bmm_ein(A′, B′) = @ein C[i,k,b] := A′[i,j,b] * B′[b,k,j]

julia> bmm_rev(A′, B′) ≈ bmm_ein(A′, B′)
true

julia> @btime bmm_ein($A′, $B′);
  1.723 ms (72 allocations: 7.64 MiB)
```
after
```julia
julia> @btime bmm_rev($A′, $B′);
  658.432 μs (60 allocations: 3.06 MiB)
```