### PR TITLE
Add nograd keyword

### DIFF
--- a/src/forward.jl
+++ b/src/forward.jl
@@ -10,7 +10,7 @@ function insert_forward_gradient(axislist, store)
 
     epsilondict = Dict{Symbol,Expr}()
 
-    epsilonright = MacroTools_postwalk(epsilonwalk(epsilondict), store.right)
+    epsilonright = MacroTools_postwalk(epsilonwalk(epsilondict, store), store.right)
     # epsilonright = MacroTools_postwalk(epsilonwalk(epsilondict, store.scalars), store.right)
 
     defineepsilons, readepsilons = [], []
@@ -43,10 +43,11 @@ function insert_forward_gradient(axislist, store)
 
 end
 
-epsilonwalk(dict) = ex -> begin
+epsilonwalk(dict, store) = ex -> begin
 # epsilonwalk(dict, scalars) = ex -> begin
 #         ex isa Symbol && ex in scalars && return scalarplusepsilon(ex, dict)
         @capture_(ex, A_[inds__]) || return ex
+        A in store.nograd && return ex
         return arrayplusepsilon(A, inds, dict)
     end
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -122,12 +122,23 @@ function parse_options(exs...)
         :tensor => _TENSOR[],
         )
     expr = nothing
+    nograd = Symbol[]
     ranges = Tuple[]
     for ex in exs
         # Actual options:
         if ex isa Expr && ex.head == :(=) && haskey(OPTS, ex.args[1])
             checklegal(ex.args[1], ex.args[2])
             opts[ex.args[1]] = ex.args[2]
+
+        # Nograd keyword
+        elseif ex isa Expr && ex.head == :(=) && ex.args[1] == :nograd
+            if ex.args[2] isa Symbol
+                push!(nograd, ex.args[2])
+            elseif ex.args[2] isa Expr && ex.args[2].head == :tuple
+                append!(nograd, ex.args[2].args)
+            else
+                error("this accepts nograd=A or nograd=(A,B,C)")
+            end
 
         # Ranges specified outside:
         elseif ex isa Expr && ex.head == :call && ex.args[1] in [:in, :∈]
@@ -144,7 +155,7 @@ function parse_options(exs...)
 
         # The main course!
         elseif ex isa Expr
-            isnothing(expr) || error("too many expressions! recognised keywords are $(keys(opts))")
+            isnothing(expr) || error("too many expressions! recognised keywords are $(vcat(:nograd, keys(opts)))")
             expr = ex
         else
             error("not sure what to do with input $ex")
@@ -166,7 +177,8 @@ function parse_options(exs...)
         grad=opts[:grad],
         avx=opts[:avx],
         cuda=opts[:cuda],
-        tensor=opts[:tensor]
+        tensor=opts[:tensor],
+        nograd=nograd,
     ), ranges, expr
 end
 
@@ -323,7 +335,8 @@ saveconstraints(A, inds, store, right=true) = begin
     end
     if right
         append!(store.rightind, is)
-        if isassigned(store.sharedind)
+        if A1 in store.nograd # then don't care whether it sharesindices
+        elseif isassigned(store.sharedind)
             shared = intersect(is, store.sharedind) # ?? is this right for multiple indices?
             empty!(store.sharedind)
             append!(store.sharedind, shared)
@@ -897,7 +910,11 @@ function backward_definitions(store)
     gradarrays = map(A -> Symbol(DEL, A), store.arrays)
     # gradscalars = map(A -> Symbol(DEL, A), store.scalars)
     defineempties = map(store.arrays, gradarrays) do A, dA
-        :( local $dA = fill!(similar($A, Base.promote_type(eltype($A), $TYP)), 0) )
+        if A in store.nograd
+            :(local $dA = nothing)
+        else
+            :( local $dA = fill!(similar($A, Base.promote_type(eltype($A), $TYP)), 0) )
+        end
     end
     # append!(defineempties, map((x,dx) -> :($dx = zero(Base.promote_type(typeof($x), $TYP))), store.scalars, gradscalars))
     returns = vcat(gradarrays, map(_->:nothing, store.scalars)) # ?? needs a test!

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -19,7 +19,7 @@ function insert_symbolic_gradient(axislist, store)
     end
 
     targets = []
-    MacroTools_postwalk(symbwalk(targets), store.right)
+    MacroTools_postwalk(symbwalk(targets, store), store.right)
     # append!(targets, scalars)
 
     inbody, prebody = [], []
@@ -130,8 +130,9 @@ end
 # but seemed simple enough to just write out, using rules from:
 # http://www.juliadiff.org/DiffRules.jl/latest/
 
-symbwalk(targets) = ex -> begin
+symbwalk(targets, store) = ex -> begin
         @capture_(ex, A_[inds__]) && A isa Symbol || return ex
+        A in store.nograd && return ex
         deltaex = :($(Symbol(DEL, A))[$(inds...)])
         push!(targets, (deltaex, ex))
         return ex

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -256,3 +256,14 @@ if Tullio._GRAD[] != :Dual
     end
 end
 
+if GRAD == :Zygote && Tullio._GRAD[] == :Base
+    @testset "nograd keyword" begin
+
+        f2(x,y) = @tullio out[i,j] := x[i] + y[j]  nograd=y threads=false
+        @test _gradient(sum∘f2, rand(2), rand(2)) == ([2,2], nothing)
+
+        f3(x,y,z) = @tullio out[i,j] := x[i] + y[j] * z[k]  nograd=(x,z) threads=false
+        @test _gradient(sum∘f3, rand(2), rand(2), ones(2)) == (nothing, [4,4], nothing)
+
+    end
+end

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -256,7 +256,7 @@ if Tullio._GRAD[] != :Dual
     end
 end
 
-if GRAD == :Zygote && Tullio._GRAD[] == :Base
+if GRAD == :Zygote
     @testset "nograd keyword" begin
 
         f2(x,y) = @tullio out[i,j] := x[i] + y[j]  nograd=y threads=false


### PR DESCRIPTION
Makes this example from the reame work, without trying to allocate `Δfs` of some weird zeros:
```julia
fs = [sin, cos, tan]
xs = randn(3,100)

rowmap(fs, xs) = @tullio ys[r,c] := (fs[r])(xs[r,c])  grad=Dual  nograd=fs
rowmap(fs, xs) 

using Zygote, ForwardDiff
Zygote.gradient(sum∘rowmap, fs, ones(3,2))
[f'(1) for f in fs]
```