### PR TITLE
Add finalisers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ But it also co-operates with various other packages, provided they are loaded be
 
 * It can use [`TensorOperations.@tensor`](https://github.com/Jutho/TensorOperations.jl) on expressions which this understands. (Disable with `tensor=false`.) These must be Einstein-convention contractions of one term; none of the examples above qualify.
 
-The macro also tries to provide a gradient for use with [Tracker](https://github.com/FluxML/Tracker.jl) or [Zygote](https://github.com/FluxML/Zygote.jl). <!-- or [ReverseDiff](https://github.com/JuliaDiff/ReverseDiff.jl). --> (Disable with `grad=false`.) This is done in one of two ways:
+The macro also tries to provide a gradient for use with [Tracker](https://github.com/FluxML/Tracker.jl) or [Zygote](https://github.com/FluxML/Zygote.jl). <!-- or [ReverseDiff](https://github.com/JuliaDiff/ReverseDiff.jl). -->
+(Disable with `grad=false`, or `nograd=A`.) This is done in one of two ways:
 
 * By default it takes a symbolic derivative of the right hand side expression. When using `@tensor`, this writes another `@tensor` expression for each input array, otherwise it simply fills in all the gradient arrays at once. (Only for reductions over `+` or `min`/`max`.)
 
@@ -176,6 +177,7 @@ The default setting is:
 * `threads=false` turns off threading, while `threads=64^3` sets a threshold size at which to divide the work (replacing the macro's best guess).
 * `avx=false` turns off the use of `LoopVectorization`, while `avx=4` inserts `@avx unroll=4 for i in ...`.
 * `grad=false` turns off gradient calculation, and `grad=Dual` switches it to use `ForwardDiff` (which must be loaded).
+* `nograd=A` turns of the gradient calculation just for `A`, and `nograd=(A,B,C)` does this for several arrays. 
 * `tensor=false` turns off the use of `TensorOperations`.
 * Assignment `xi = ...` removes `xi` from the list of indices: its range is note calculated, and it will not be summed over. It also disables `@inbounds` since this is now up to you.
 * `verbose=true` prints things like the index ranges inferred, and gradient calculations. `verbose=2` prints absolutely everything.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Here the macro cannot infer the range of the output's indices `x,y`, so they mus
 It knows that it should not sum over indices `i,j`, but since it can't be sure  of their ranges, it will not add `@inbounds` in such cases.
 It will also not be able to take a symbolic derivative here, but dual numbers will work fine.
 
+Pipe operators `|>` and `<|` indicate functions to be performed *outside* the sum, for example:
+
+```julia
+@tullio lse[j] := log <| exp(mat[i,j])   # vec(log.(sum(exp.(mat), dims=1))) 
+```
+
 The option `@tullio verbose=true` will cause it to print index ranges, symbolic derivatives,
 and notices when it is unable to use the packages mentioned above.
 
@@ -72,7 +78,11 @@ K = OffsetArray([1,-1,2,-1,1], -2:2)
 
 using FFTW # Functions of the indices are OK:
 S = [0,1,0,0, 0,0,0,0]
-fft(S) ≈ @tullio (k ∈ axes(S,1)) F[k] := S[x] * exp(-im*pi/8 * (k-1) * x)
+fft(S) ≈ @tullio F[k] := S[x] * exp(-im*pi/8 * (k-1) * x)  (k ∈ axes(S,1))
+
+# Finalisers <| or |> are applied after sum:
+@tullio N2[j] := sqrt <| M[i,j]^2   # N2 == vec(mapslices(norm, M, dims=1))
+@tullio n3 := A[i]^3  |> (_)^(1/3)  # n3 == norm(A,3), with _ anon. func.
 
 # Reduction over any function:
 @tullio (*) P[i] := A[i+k]  (k in 0:2) # product

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ S = [0,1,0,0, 0,0,0,0]
 fft(S) ≈ @tullio F[k] := S[x] * exp(-im*pi/8 * (k-1) * x)  (k ∈ axes(S,1))
 
 # Finalisers <| or |> are applied after sum:
-@tullio N2[j] := sqrt <| M[i,j]^2   # N2 == vec(mapslices(norm, M, dims=1))
-@tullio n3 := A[i]^3  |> (_)^(1/3)  # n3 == norm(A,3), with _ anon. func.
+@tullio N2[j] := sqrt <| M[i,j]^2   # N2 ≈ map(norm, eachcol(M)) 
+@tullio n3 := A[i]^3  |> (_)^(1/3)  # n3 ≈ norm(A,3), with _ anon. func.
 
 # Reduction over any function:
 @tullio (*) P[i] := A[i+k]  (k in 0:2) # product

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -53,11 +53,11 @@ using Requires
     using .CuArrays
 
     Tullio.threader(fun!::Function, T::Type{<:CuArray},
-        Z::AbstractArray, As::Tuple, Is::Tuple, Js::Tuple; block=0, keep=nothing) =
+        Z::AbstractArray, As::Tuple, Is::Tuple, Js::Tuple, redfun, block=0, keep=nothing) =
         fun!(T, Z, As..., Is..., Js..., keep)
 
     Tullio.∇threader(fun!::Function, T::Type{<:CuArray},
-        As::Tuple, Is::Tuple, Js::Tuple; block=0) =
+        As::Tuple, Is::Tuple, Js::Tuple, block=0) =
         fun!(T, As..., Is..., Js...,)
 
 end
@@ -67,11 +67,11 @@ end
     using .CUDA
 
     Tullio.threader(fun!::Function, T::Type{<:CuArray},
-        Z::AbstractArray, As::Tuple, Is::Tuple, Js::Tuple; block=0, keep=nothing) =
+        Z::AbstractArray, As::Tuple, Is::Tuple, Js::Tuple, redfun, block=0, keep=nothing) =
         fun!(T, Z, As..., Is..., Js..., keep)
 
     Tullio.∇threader(fun!::Function, T::Type{<:CuArray},
-        As::Tuple, Is::Tuple, Js::Tuple; block=0) =
+        As::Tuple, Is::Tuple, Js::Tuple, block=0) =
         fun!(T, As..., Is..., Js...,)
 
 end

--- a/src/forward.jl
+++ b/src/forward.jl
@@ -2,6 +2,8 @@
 #========== backward gradient using ForwardDiff ==========#
 
 function insert_forward_gradient(axislist, store)
+    store.finaliser == :identity || error("can't use grad=Dual with |> finaliser")
+
     dZ = Symbol(DEL, ZED)
     ∇act! = Symbol(:∇, ACT!)
     gradarrays = map(A -> Symbol(DEL, A), store.arrays)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -675,13 +675,20 @@ function action_functions(store)
 
     ex_iter = :( $ACC = $(store.redfun)($ACC, $(store.right) ) )
 
-    # ex_write = :( isnothing($FINAL) ? ($ZED[$(store.leftraw...)] = $ACC) : ($ZED[$(store.leftraw...)] = $(store.finaliser)($ACC)) )
-    # ex_write = :( $ZED[$(store.leftraw...)] = isnothing($FINAL) ? $ACC : $(store.finaliser)($ACC) )
-    ex_write = :( $ZED[$(store.leftraw...)] = ifelse(isnothing($FINAL), $ACC, $(store.finaliser)($ACC)) )
+    ex_write = if store.finaliser == :identity
+        :( $ZED[$(store.leftraw...)] = $ACC )
+    else
+        # :( $ZED[$(store.leftraw...)] = isnothing($FINAL) ? $ACC : $(store.finaliser)($ACC) )
+        :( $ZED[$(store.leftraw...)] = ifelse(isnothing($FINAL), $ACC, $(store.finaliser)($ACC)) )
+    end
 
-    ex_nored = quote
-        $RHS = isnothing($KEEP) ? $(store.right) : $(store.redfun)($ZED[$(store.leftraw...)] ,$(store.right))
-        $ZED[$(store.leftraw...)] = ifelse(isnothing($FINAL), $RHS, $(store.finaliser)($RHS))
+    ex_nored = if store.finaliser == :identity
+        :( $ZED[$(store.leftraw...)] = isnothing($KEEP) ? $(store.right) : $(store.redfun)($ZED[$(store.leftraw...)] ,$(store.right)) )
+    else
+        quote
+            $RHS = isnothing($KEEP) ? $(store.right) : $(store.redfun)($ZED[$(store.leftraw...)] ,$(store.right))
+            $ZED[$(store.leftraw...)] = ifelse(isnothing($FINAL), $RHS, $(store.finaliser)($RHS))
+        end
     end
 
     if isempty(store.redind)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -938,9 +938,13 @@ function backward_definitions(store)
 
     ok = false
     if store.grad == :Dual && store.redfun == :+
-        insert_forward_gradient(axislist, store)
-        ok = true
-        store.verbose == 2 && @info "using ForwardDiff gradient"
+        try
+            insert_forward_gradient(axislist, store)
+            ok = true
+            store.verbose == 2 && @info "using ForwardDiff gradient"
+        catch err
+            store.verbose > 0 && @warn "ForwardDiff gradient failed" err
+        end
     elseif store.grad == :Base
         try
             insert_symbolic_gradient(axislist, store)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -799,7 +799,7 @@ function make_many_actors(act!, args, ex1, outer::Vector, ex3, inner::Vector, ex
 
             kex1 = macroexpand(store.mod, quote
 
-                KernelAbstractions.@kernel function $kernel($(args...), $KEEP) where {$TYP}
+                KernelAbstractions.@kernel function $kernel($(args...), $KEEP, $FINAL) where {$TYP}
                     ($(outer...),) = @index(Global, NTuple)
                     ($ex1; $ex3; $ex4; $ex6)
                 end
@@ -814,7 +814,7 @@ function make_many_actors(act!, args, ex1, outer::Vector, ex3, inner::Vector, ex
                         $info2
                         cu_kern! = $kernel(CUDA(), $(store.cuda))
                         $(asserts...)
-                        $ACC = cu_kern!($(args...), $KEEP; ndrange=tuple($(sizes...)))
+                        $ACC = cu_kern!($(args...), $KEEP, $FINAL; ndrange=tuple($(sizes...)))
                         KernelAbstractions.wait($ACC)
                     end
 
@@ -829,7 +829,7 @@ function make_many_actors(act!, args, ex1, outer::Vector, ex3, inner::Vector, ex
                         $info2bis
                         cu_kern! = $kernel(CUDADevice(), $(store.cuda))
                         $(asserts...)
-                        $ACC = cu_kern!($(args...), $KEEP; ndrange=tuple($(sizes...)))
+                        $ACC = cu_kern!($(args...), $KEEP, $FINAL; ndrange=tuple($(sizes...)))
                         KernelAbstractions.wait($ACC)
                     end
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -277,8 +277,9 @@ function parse_input(expr, store)
     end
     if isnothing(store.finaliser)
         store.finaliser = :identity
-    else
-        store.threads = false # because FINAL doesn't work right yet
+    elseif :scalar in store.flags
+        # scalar threaded reduction won't work with nontrivial finalisers
+        store.threads = false
     end
     right1 = MacroTools_postwalk(rightwalk(store), right)
     store.right = MacroTools_postwalk(dollarwalk(store), right1)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -24,6 +24,11 @@ This is a product instead of a sum, which could also enabled by writing `L[i] *=
 You can use any reduction function such as `@tullio (max) M[i,j] := ...`.
 Indexing by `J[k]+2` here demands `issubset(J, axes(A,1) .- 2)`.
 
+    @tullio N[j] := sqrt <| M[i,j]^2
+
+Pipe operators `|>` and `<|` apply a function after the sum, here `N ≈ map(norm, eachcol(M))`.
+Underscores create functions, e.g. `|> sqrt(_ / V[i])` where clearly `i` must not have been summed.
+
 See the readme for further options.
 """
 macro tullio(exs...)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -281,7 +281,7 @@ function parse_input(expr, store)
             store.threads = false
         end
     else
-        store.right = MacroTools_postwalk(dollarwalk(store), right1)
+        store.right = MacroTools_postwalk(dollarwalk(store), right2)
         store.finaliser = :identity
     end
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -887,7 +887,7 @@ function make_many_actors(act!, args, ex1, outer::Vector, ex3, inner::Vector, ex
                     $info3
                     cpu_kern! = $kernel(CPU(), 4)
                     $(asserts...)
-                    $ACC = cpu_kern!($(args...), $KEEP; ndrange=tuple($(sizes...)))
+                    $ACC = cpu_kern!($(args...), $KEEP, $FINAL; ndrange=tuple($(sizes...)))
                     KernelAbstractions.wait($ACC)
                 end
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -674,13 +674,13 @@ function action_functions(store)
 
     ex_iter = :( $ACC = $(store.redfun)($ACC, $(store.right) ) )
 
-    ex_write = :( isnothing($FINAL) ? ($ZED[$(store.leftraw...)] = $ACC) : ($ZED[$(store.leftraw...)] = $(store.finaliser)($ACC)) )
+    # ex_write = :( isnothing($FINAL) ? ($ZED[$(store.leftraw...)] = $ACC) : ($ZED[$(store.leftraw...)] = $(store.finaliser)($ACC)) )
+    # ex_write = :( $ZED[$(store.leftraw...)] = isnothing($FINAL) ? $ACC : $(store.finaliser)($ACC) )
+    ex_write = :( $ZED[$(store.leftraw...)] = ifelse(isnothing($FINAL), $ACC, $(store.finaliser)($ACC)) )
 
-    RHSprime = Symbol(RHS, "′")
     ex_nored = quote
         $RHS = isnothing($KEEP) ? $(store.right) : $(store.redfun)($ZED[$(store.leftraw...)] ,$(store.right))
-        $RHSprime = isnothing($FINAL) ? $RHS : $(store.finaliser)($RHS)
-        $ZED[$(store.leftraw...)] = $RHSprime
+        $ZED[$(store.leftraw...)] = ifelse(isnothing($FINAL), $RHS, $(store.finaliser)($RHS))
     end
 
     if isempty(store.redind)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -653,11 +653,13 @@ function action_functions(store)
 
     ex_iter = :( $ACC = $(store.redfun)($ACC, $(store.right) ) )
 
-    ex_write = :( $ZED[$(store.leftraw...)] = isnothing($FINAL) ? $ACC : $(store.finaliser)($ACC) )
+    ex_write = :( isnothing($FINAL) ? ($ZED[$(store.leftraw...)] = $ACC) : ($ZED[$(store.leftraw...)] = $(store.finaliser)($ACC)) )
 
+    RHSprime = Symbol(RHS, "′")
     ex_nored = quote
         $RHS = isnothing($KEEP) ? $(store.right) : $(store.redfun)($ZED[$(store.leftraw...)] ,$(store.right))
-        $ZED[$(store.leftraw...)] = isnothing($FINAL) ? $RHS : ($(store.finaliser))($RHS)
+        $RHSprime = isnothing($FINAL) ? $RHS : $(store.finaliser)($RHS)
+        $ZED[$(store.leftraw...)] = $RHSprime
     end
 
     if isempty(store.redind)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -718,7 +718,7 @@ function action_functions(store)
     push!(store.outex, quote
         $threader($ACT!, $ST, $(store.leftarray),
             tuple($(store.arrays...), $(store.scalars...), $(axisunsafe...),),
-            tuple($(axisleft...),), tuple($(axisred...),), $block, $keep)
+            tuple($(axisleft...),), tuple($(axisred...),), $(store.redfun), $block, $keep)
         $(store.leftarray)
     end)
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -79,10 +79,13 @@ function insert_symbolic_gradient(axislist, store)
 
 end
 
-leibfinal(fun::Symbol, res) = begin
-    # if :fun ==
-    _leibfinal(:($fun($RHS)), res)
-end
+leibfinal(fun::Symbol, res) =
+    if fun == :log
+        :(exp(-$res)) # this exp gets done at every element :(
+        # :(inv(exp($res)))
+    else
+        _leibfinal(:($fun($RHS)), res)
+    end
 
 _leibfinal(out, res) = begin
     grad1 = leibnitz(out, RHS)
@@ -107,6 +110,12 @@ leibfinal(ex::Expr, res) = begin
     error("couldn't understand finaliser")
 end
 
+#=
+Tullio.leibfinal(:exp, :res)   # :res
+Tullio.leibfinal(:sqrt, :res)  # :(inv(res) / 2)
+Tullio.leibfinal(:tanh, :res)  # :(1 - res ^ 2)
+Tullio.leibfinal(:log, :res)   # :(exp(-res))
+=#
 
 # This works for simple cases, but the general case is more complicatd.
 #=

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -79,12 +79,15 @@ function insert_symbolic_gradient(axislist, store)
 
 end
 
-leibfinal(fun, res) = begin
-    out = :($fun($RHS))
-    @show out
+leibfinal(fun::Symbol, res) = begin
+    # if :fun ==
+    _leibfinal(:($fun($RHS)), res)
+end
+
+_leibfinal(out, res) = begin
     grad1 = leibnitz(out, RHS)
     grad2 = MacroTools_postwalk(grad1) do ex
-        @show ex ex == out
+        # @show ex ex == out
         ex == out ? res : ex
     end
     MacroTools_postwalk(grad2) do ex

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -95,6 +95,19 @@ _leibfinal(out, res) = begin
     end
 end
 
+leibfinal(ex::Expr, res) = begin
+    if ex.head == :call && ex.args[1] isa Expr &&
+        ex.args[1].head == :(->) && ex.args[1].args[1] == RHS # then it came from underscores
+        inner = ex.args[1].args[2]
+        if inner isa Expr && inner.head == :block
+            lines = filter(a -> !(a isa LineNumberNode), inner.args)
+            length(lines) == 1 && return _leinfinal(first(lines), res)
+        end
+    end
+    error("couldn't understand finaliser")
+end
+
+
 # This works for simple cases, but the general case is more complicatd.
 #=
 product_grad(prebody, store) = begin

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -22,6 +22,11 @@ function insert_symbolic_gradient(axislist, store)
     MacroTools_postwalk(symbwalk(targets, store), store.right)
     # append!(targets, scalars)
 
+    if isempty(targets) # short-circuit
+        push!(store.outpre, :(local @inline $∇act!(::Type, args...) = nothing ))
+        return nothing
+    end
+
     inbody, prebody = [], []
     for (dt, t) in unique(targets)
         drdt = leibnitz(store.right, t)

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -97,17 +97,17 @@ end
 
 const MINIBLOCK = Ref(64^3) # 2x quicker matmul at size 1000
 
-function block_halves(fun!::Function, T::Type, As::Tuple, Is::Tuple, Js::Tuple, keep=nothing)
+function block_halves(fun!::Function, T::Type, As::Tuple, Is::Tuple, Js::Tuple, keep=nothing, final=true)
     if productlength(Is,Js) <= MINIBLOCK[]
-        return fun!(T, As..., Is..., Js..., keep)
+        return fun!(T, As..., Is..., Js..., keep, final)
     elseif maximumlength(Is) > maximumlength(Js)
         I1s, I2s = cleave(Is)
-        block_halves(fun!, T, As, I1s, Js, keep)
-        block_halves(fun!, T, As, I2s, Js, keep)
+        block_halves(fun!, T, As, I1s, Js, keep, final)
+        block_halves(fun!, T, As, I2s, Js, keep, final)
     else
         J1s, J2s = cleave(Js)
-        block_halves(fun!, T, As, Is, J1s, keep)
-        block_halves(fun!, T, As, Is, J2s, true)
+        block_halves(fun!, T, As, Is, J1s, keep, false)
+        block_halves(fun!, T, As, Is, J2s, true, final)
     end
     nothing
 end

--- a/src/threads.jl
+++ b/src/threads.jl
@@ -98,6 +98,8 @@ end
 const MINIBLOCK = Ref(64^3) # 2x quicker matmul at size 1000
 
 function block_halves(fun!::Function, T::Type, As::Tuple, Is::Tuple, Js::Tuple, keep=nothing, final=true)
+    keep == nothing || keep == true || error("illegal value for keep")
+    final == nothing || final == true || error("illegal value for final")
     if productlength(Is,Js) <= MINIBLOCK[]
         return fun!(T, As..., Is..., Js..., keep, final)
     elseif maximumlength(Is) > maximumlength(Js)
@@ -106,7 +108,7 @@ function block_halves(fun!::Function, T::Type, As::Tuple, Is::Tuple, Js::Tuple, 
         block_halves(fun!, T, As, I2s, Js, keep, final)
     else
         J1s, J2s = cleave(Js)
-        block_halves(fun!, T, As, Is, J1s, keep, false)
+        block_halves(fun!, T, As, Is, J1s, keep, nothing)
         block_halves(fun!, T, As, Is, J2s, true, final)
     end
     nothing

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -267,6 +267,9 @@ if Tullio._GRAD[] != :Dual
         layer(x) = @tullio y[i,k] := mat[i,j] * x[j,k] |> tanh
         @test gradtest(layer, (3,4))
 
+        lse1(mat) = @tullio lse[j] := log <| exp(mat[i,j])
+        @test gradtest(lse1, (3,4))
+
         # relu(x) = max(x, zero(x))
         # lay2(x) = @tullio y[i,k] := mat[i,j] * x[j,k] |> relu
 

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -254,5 +254,26 @@ if Tullio._GRAD[] != :Dual
         @test dv ≈ _gradient(sum∘f9, m4, v2)[2]
 
     end
+
+    @testset "finalisers" begin
+
+        norm2(m) = @tullio n[i] := m[i,j]^2 |> sqrt
+
+        gradtest(norm2, (3,4))
+        mat = rand(3,3)
+        @test _gradient(sum∘norm2, mat)[1] ≈ ForwardDiff.gradient(sum∘norm2, mat)
+        @test gradtest(norm2, (3,4))
+
+        layer(x) = @tullio y[i,k] := mat[i,j] * x[j,k] |> tanh
+        @test gradtest(layer, (3,4))
+
+        # relu(x) = max(x, zero(x))
+        # lay2(x) = @tullio y[i,k] := mat[i,j] * x[j,k] |> relu
+
+        mx3(x) = @tullio (max) r[i] := x[i,j]^3 |> cbrt
+        mx3(mat) # hmmm what is this?
+        _gradient(sum∘mx3, mat)[1] # zero
+
+    end
 end
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -397,9 +397,12 @@ end
     @tullio (max) E[i] := float(B[i,j]) |> atan(_, A[i]) # i is not reduced over
     @test E ≈ vec(atan.(maximum(B, dims=2), A))
 
-    # neither of these is caught by my code, but both should be:
+    j = 2
+    @tullio G[i'] := float(B[i',j]) |> atan(_, B[i',$j])
+    @test G ≈ vec(atan.(sum(B, dims=2), B[:,j]))
+
     @test_throws Exception @tullio F[i] := B[i,j] |> (_ / A[j]) # wrong index
-    @test_skip @test_throws Exception @tullio F[i] := B[i,j] |> (_ / C[i]) # wrong length
+    @test_throws Exception @tullio F[i] := B[i,j] |> (_ / C[i]) # wrong length
 
 end
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -385,7 +385,9 @@ end
     @tullio D2[_,j] := D[i,j]^2 |> sqrt
     @test D2 ≈ mapslices(norm, D, dims=1)
 
-    # functions with _
+    # functions with underscores
+    @tullio n2′ = A[i]^2 |> (_)^0.5
+    @test n2′ ≈ norm(A,2)
 
 end
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -361,6 +361,11 @@ end
     @test_throws Exception @eval @tullio s += (*) A[i]
     @test_throws Exception @eval @tullio s *= (max) A[i]
 
+    # scalar + threading
+    L = randn(10 * Tullio.MINIBLOCK[]);
+    @tullio (max) m := L[i]
+    @test_broken m == maximum(L)
+
 end
 
 @testset "finalisers" begin

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -382,11 +382,11 @@ end
     @test B2 ≈ mapslices(norm, B + B', dims=1)
 
     # larger size, to trigger threads & blocks
-    C = randn(10 * Tullio.BLOCK[])
+    C = randn(10^6) # > Tullio.BLOCK[]
     @tullio n2 = C[i]^2 |> sqrt
     @test n2 ≈ norm(C,2)
 
-    D = rand(2 * Tullio.MINIBLOCK[], 2 * Tullio.MINIBLOCK[])
+    D = rand(1000, 1000) # > Tullio.MINIBLOCK[]
     @tullio D2[_,j] := D[i,j]^2 |> sqrt
     @test D2 ≈ mapslices(norm, D, dims=1)
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -362,9 +362,9 @@ end
     @test_throws Exception @eval @tullio s *= (max) A[i]
 
     # scalar + threading
-    L = randn(10 * Tullio.MINIBLOCK[]);
+    L = randn(100 * Tullio.MINIBLOCK[]);
     @tullio (max) m := L[i]
-    @test_broken m == maximum(L)
+    @test m == maximum(L)
 
 end
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -401,7 +401,7 @@ end
     @tullio G[i'] := float(B[i',j]) |> atan(_, B[i',$j])
     @test G ≈ vec(atan.(sum(B, dims=2), B[:,j]))
 
-    @test_throws Exception @tullio F[i] := B[i,j] |> (_ / A[j]) # wrong index
+    @test_throws Exception @eval @tullio F[i] := B[i,j] |> (_ / A[j]) # wrong index
     @test_throws Exception @tullio F[i] := B[i,j] |> (_ / C[i]) # wrong length
 
 end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -363,6 +363,32 @@ end
 
 end
 
+@testset "finalisers" begin
+
+    A = [i^2 for i in 1:10]
+    @tullio n2 = A[i]^2 |> sqrt
+    @test n2 ≈ norm(A,2)
+    @tullio n3 := cbrt <| A[i]^3
+    @test n3 ≈ norm(A,3)
+
+    @tullio B[i,j] := A[i] + A[k] // A[j]
+
+    @tullio B2[_,j] := (B[i,j] + B[j,i])^2 |> sqrt
+    @test B2 ≈ mapslices(norm, B + B', dims=1)
+
+    # larger size, to trigger threads & blocks
+    C = randn(500)
+    @tullio n2 = C[i]^2 |> sqrt
+    @test n2 ≈ norm(C,2)
+
+    D = randn(100,100)
+    @tullio D2[_,j] := D[i,j]^2 |> sqrt
+    @test D2 ≈ mapslices(norm, D, dims=1)
+
+    # functions with _
+
+end
+
 @testset "named dimensions" begin
 
     using NamedDims

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,8 @@ if CUDA.has_cuda_gpu()
 end
 =#
 
+@tullio cuda=false
+
 @info @sprintf("KernelAbstractions tests took %.1f seconds", time()-t4)
 
 #===== Zygote =====#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,14 @@
 
 using Test, Printf
 
-@info "Testing with $(Threads.nthreads()) threads"
-
 t1 = @elapsed using Tullio
 @info @sprintf("Loading Tullio took %.1f seconds", t1)
 
-Tullio.BLOCK[] = 32 # use threading even on small arrays
-Tullio.MINIBLOCK[] = 32
+@info "Testing with $(Threads.nthreads()) threads"
+if Threads.nthreads() > 1 # use threading even on small arrays
+    Tullio.BLOCK[] = 32
+    Tullio.MINIBLOCK[] = 32
+end
 
 #===== stuff =====#
 


### PR DESCRIPTION
This allows a function to act after the reduction, something like `sqrt.(sum(D.^2, dims=1))`:
```julia
@tullio E[_,j] := D[i,j]^2 |> sqrt
E ≈ mapslices(norm, D, dims=1)
```
The gradient would in principle need the result of the sum before `sqrt`, which isn't saved. But since the derivative contains `sqrt(pre)`, it can substitute in the final result `E[1,j]` instead.
```julia
Tullio.leibnitz(:(sqrt(pre)), :pre) # :(inv(sqrt(pre)) / 2)
```