### PR TITLE
Allow scatter operations

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -458,6 +458,7 @@ finishleftraw(leftraw, store) = map(enumerate(leftraw)) do (d,i)
         if :newarray in store.flags
             ax_i = Symbol(AXIS, string("≪", ex, "≫")) # fake index name, to which to attach a size?
             push!(store.axisdefs, :(local $ax_i = $extremerange($J)))
+            push!(store.flags, :zero)
         # else
         #     Zed = store.leftarray
         #     str = "extrema of index $ex must fit within axes($Zed,$d) (twice?)"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -457,13 +457,13 @@ finishleftraw(leftraw, store) = map(enumerate(leftraw)) do (d,i)
         ex = :($J[$(tidyleftraw(inds, store)...)])
         if :newarray in store.flags
             ax_i = Symbol(AXIS, string("≪", ex, "≫")) # fake index name, to which to attach a size?
-            push!(store.axisdefs, :(local $ax_i = UnitRange(extrema($J)...)))
-        else
-            Zed = store.leftarray
-            str = "extrema of index $ex must fit within axes($Zed,$d)"
-            push!(store.outpre, :(issubset(UnitRange(extrema($J)...), axes($Zed,$d)) || error($str)))
-        end
-        if !(:plusequals in store.flags) # A[i,J[j,k]] += ... doesn't zero
+            push!(store.axisdefs, :(local $ax_i = $extremerange($J)))
+        # else
+        #     Zed = store.leftarray
+        #     str = "extrema of index $ex must fit within axes($Zed,$d) (twice?)"
+        #     push!(store.outpre, :(issubset($extremerange($J), axes($Zed,$d)) || error($str)))
+        # end
+        elseif !(:plusequals in store.flags) # A[i,J[j,k]] += ... doesn't zero
             push!(store.flags, :zero)
         end
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -459,11 +459,6 @@ finishleftraw(leftraw, store) = map(enumerate(leftraw)) do (d,i)
             ax_i = Symbol(AXIS, string("≪", ex, "≫")) # fake index name, to which to attach a size?
             push!(store.axisdefs, :(local $ax_i = $extremerange($J)))
             push!(store.flags, :zero)
-        # else
-        #     Zed = store.leftarray
-        #     str = "extrema of index $ex must fit within axes($Zed,$d) (twice?)"
-        #     push!(store.outpre, :(issubset($extremerange($J), axes($Zed,$d)) || error($str)))
-        # end
         elseif !(:plusequals in store.flags) # A[i,J[j,k]] += ... doesn't zero
             push!(store.flags, :zero)
         end

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -70,7 +70,7 @@ function _tullio(exs...; mod=Main)
         scalars = Symbol[],
         cost = 1,
     # Index ranges: first save all known constraints
-        constraints = Dict{Symbol,Vector}(), # :k => [:(axis(A,2)), :(axis(B,1))] etc.
+        constraints = Dict{Symbol,Vector}(), # :k => [:(axes(A,2)), :(axes(B,1))] etc.
         notfree = Symbol[], # indices assigned values i = clamp(j, 1,3) within RHS
         shiftedind = Symbol[],
         pairconstraints = Tuple[], # (:i, :j, entangled range_i, range_j) from A[i+j] etc.
@@ -254,13 +254,14 @@ function parse_input(expr, store)
     else
         error("can't understand LHS, expected A[i,j,k], got $left")
     end
-    leftraw1 = tidyleftraw(primeindices(leftraw), store)
-    store.leftind = filter(i -> i isa Symbol, leftraw1) # this gives correct outer loop order
-    store.leftraw = tidyleftraw2(leftraw1, store)
+    leftraw2 = tidyleftraw(leftraw, store)
+    store.leftind = filter(i -> i isa Symbol, leftraw2) # this gives correct outer loop order
 
     isnothing(Z) && !(:newarray in store.flags) && error("can't write into an array whose name isn't given!")
     Zed = isnothing(Z) ? ZED : Z
     store.leftarray = Zed
+
+    store.leftraw = finishleftraw(leftraw2, store)
     if :newarray in store.flags
         !allunique(store.leftind) && push!(store.flags, :zero) # making diagonals, etc.
         Zed in store.arrays && error("can't create a new array $Zed when this also appears on the right")
@@ -427,25 +428,46 @@ dollarstrip(expr) = MacroTools_postwalk(expr) do @nospecialize ex
         ex
     end
 
-# there has got to be a tidier way!
-tidyleftraw(leftraw, store) = map(leftraw) do i
-    if i isa Expr && i.head == :kw
-        if :newarray in store.flags # then NamedDims wrapper is put on later
-            push!(store.leftnames, i.args[1])
-            return i.args[2]
-        else
-            # push!(store.flags, :noavx)
+tidyleftraw(leftraw, store) = begin
+    step1 = map(leftraw) do i
+        if i isa Expr && i.head == :kw && :newarray in store.flags # then NamedDims wrapper is put on later
+                push!(store.leftnames, i.args[1])
+                return i.args[2]
+        elseif i === :_ # underscores on left denote trivial dimensions
+            return 1
         end
-    elseif i === :_
-        return 1
+        i
     end
-    i
+    primeindices(step1) # normalise i' to i′
 end
-tidyleftraw2(leftraw, store) = map(leftraw) do i
+
+finishleftraw(leftraw, store) = map(enumerate(leftraw)) do (d,i)
     if i isa Expr && i.head == :$
+        :newarray in store.flags && error("can't fix indices on LHS when making a new array")
         i.args[1] isa Symbol || error("you can only interpolate single symbols, not $ex")
         push!(store.scalars, i.args[1])
         return i.args[1]
+
+    elseif @capture_(i, J_[inds__]) # scatter operation, A[i,J[j,k]] := ...
+        push!(store.nograd, J)
+        rightwalk(store)(i) # array J viewed as part of RHS, and provides a range for j,k
+        inds2 = filter(j->j isa Symbol, tidyleftraw(inds, store))
+        append!(store.leftind, inds2) # but j,k aren't to be summed
+
+        ex = :($J[$(tidyleftraw(inds, store)...)])
+        if :newarray in store.flags
+            ax_i = Symbol(AXIS, string("≪", ex, "≫")) # fake index name, to which to attach a size?
+            push!(store.axisdefs, :(local $ax_i = UnitRange(extrema($J)...)))
+        else
+            Zed = store.leftarray
+            str = "extrema of index $ex must fit within axes($Zed,$d)"
+            push!(store.outpre, :(issubset(UnitRange(extrema($J)...), axes($Zed,$d)) || error($str)))
+        end
+        if !(:plusequals in store.flags) # A[i,J[j,k]] += ... doesn't zero
+            push!(store.flags, :zero)
+        end
+
+        return ex # has primes dealt with
     end
     i
 end
@@ -621,13 +643,14 @@ function output_array(store)
         outaxes = map(store.leftraw) do i
             i isa Integer && i==1 && return :(Base.OneTo(1))
             i isa Symbol && return Symbol(AXIS, i)
+            i isa Expr && @capture_(i, J_[inds__]) && return Symbol(AXIS, string("≪", i, "≫"))
             error("can't use index $i on LHS for a new array")
         end
 
         if !isdefined(store.mod, :OffsetArrays)
             outaxes = map(store.leftraw, outaxes) do i, ax
                 ax == :(Base.OneTo(1)) && return ax
-                i in store.shiftedind || return ax
+                i in store.shiftedind || @capture_(i, J_[inds__]) || return ax
                 push!(store.outex, :( first($ax) == 1 || error("to allow indices not starting at 1, OffsetArrays must be visible in the caller's module")))
                 return :(Base.OneTo($ax))
             end
@@ -654,7 +677,7 @@ function output_array(store)
     end
 
     if :zero in store.flags
-        push!(store.outex, :( $(store.leftarray) .= zero($TYP) ))
+        push!(store.outex, :( $(store.leftarray) .= false )) # zero($TYP) won't work in-place
     end
 
 end

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -51,13 +51,23 @@ end
 # which is what's now used for this:
 @test _gradient(x -> (@tullio y := log(x[i])), collect(1:3.0))[1] == 1 ./ (1:3)
 
-# indexing
+# gather/scatter
 inds = vcat(1:3, 1:2)
 @test _gradient(x -> sum(@tullio y[i] := x[inds[i]]), rand(3))[1] == [2,2,1]
 
-ind2 = rand(1:10, 1024)
+_gradient(x -> sum(@tullio y[inds[i]] := x[i]), rand(5))[1] == [1,1,1,1,1]
+ForwardDiff.gradient(x -> sum(@tullio y[inds[i]] := x[i]), rand(5)) == [0,0,1,1,1]
+# hmm, is that OK?
+
+ind2 = rand(1:10, 1024) # many repeats
 dx2 = ForwardDiff.gradient(x -> sum(@tullio y[i] := x[ind2[i]] + x[i]), rand(1024))
 @test dx2 ≈ _gradient(x -> sum(@tullio y[i] := x[ind2[i]] + x[i]), rand(1024))[1]
+
+ind3 = unique(rand(1:1024, 10)) # many missing
+g3 = ForwardDiff.gradient(x -> sum(@tullio y[ind3[i]] := i^2 * x[i]), zero(ind3))
+# _gradient(x -> sum(@tullio y[ind3[i]] := i^2 * x[i]), zero(ind3))[1] # hmm, wtf?
+# testing: BoundsError: attempt to access 891-element Array{Float64,1} at index [1003]
+
 
 #=
 # shifts, etc

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -57,17 +57,16 @@ inds = vcat(1:3, 1:2)
 
 _gradient(x -> sum(@tullio y[inds[i]] := x[i]), rand(5))[1] == [1,1,1,1,1]
 ForwardDiff.gradient(x -> sum(@tullio y[inds[i]] := x[i]), rand(5)) == [0,0,1,1,1]
-# hmm, is that OK?
+# This difference may be another edge case like multiple maxima?
 
 ind2 = rand(1:10, 1024) # many repeats
 dx2 = ForwardDiff.gradient(x -> sum(@tullio y[i] := x[ind2[i]] + x[i]), rand(1024))
 @test dx2 ≈ _gradient(x -> sum(@tullio y[i] := x[ind2[i]] + x[i]), rand(1024))[1]
 
-ind3 = unique(rand(1:1024, 10)) # many missing
-g3 = ForwardDiff.gradient(x -> sum(@tullio y[ind3[i]] := i^2 * x[i]), zero(ind3))
-# _gradient(x -> sum(@tullio y[ind3[i]] := i^2 * x[i]), zero(ind3))[1] # hmm, wtf?
-# testing: BoundsError: attempt to access 891-element Array{Float64,1} at index [1003]
-
+ind3 = vcat(unique(rand(1:1024, 10)), 1) # many missing, but includes at 1
+g3 = ForwardDiff.gradient(x -> sum(@tullio y[ind3[i]] := i^2 * x[i]), ones(size(ind3)))
+@test g3 ≈ _gradient(x -> sum(@tullio y[ind3[i]] := i^2 * x[i]), ones(size(ind3)))[1]
+# You get weird errors here if indices of y don't start at 1.
 
 #=
 # shifts, etc

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -202,7 +202,7 @@ end
 
     @test_throws LoadError @eval @tullio [i,j] = A[i] + 100
 
-    # zero off-diagonal?
+    # zero off-diagonal? not now, but maybe it should?
     @tullio D[i,i] = A[i]
 
     # scatter operation
@@ -210,7 +210,7 @@ end
     inds = [2,3,5,2]
     @tullio D[inds[i],j] = A[j]
     @test D[2,:] == A
-    @test D[4,4] == 0
+    @test D[4,4] == 0 # zeroed before writing.
 
     @tullio D[inds[i],j] += A[j]
     @test D[2,:] == 3 .* A # was not re-zeroed for +=

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -215,6 +215,9 @@ end
     @tullio D[inds[i],j] += A[j]
     @test D[2,:] == 3 .* A # was not re-zeroed for +=
 
+    kinds = [1,2,13,4]
+    @test_throws Exception @tullio D[kinds[i],j] = A[j]
+
     # assignment: no loop over j
     B = zero(A);
     @tullio B[i] = begin

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -202,6 +202,9 @@ end
 
     @test_throws LoadError @eval @tullio [i,j] = A[i] + 100
 
+    # zero off-diagonal?
+    @tullio D[i,i] = A[i]
+
     # scatter operation
     D = similar(A, 10, 10) .= 999
     inds = [2,3,5,2]

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -151,6 +151,9 @@ using Tullio, Test, LinearAlgebra
     end
     @test B == (4:13) .// (1:3)'
 
+    # wrong ndims
+    @test_throws Exception @tullio Z[i] := B[i]
+
     # internal name leaks
     for sy in Tullio.SYMBOLS
         @test !isdefined(@__MODULE__, sy)
@@ -225,6 +228,12 @@ end
         A[j]
     end
     @test B == A[[mod(i^4, 1:10) for i in 1:10]]
+
+    # wrong ndims
+    @test ndims(B)==1 && ndims(D)==2
+    @test_throws Exception @tullio B[i] = D[i]^2
+    @test_throws Exception @tullio D[i] = B[i]+2
+    @test_throws Exception @tullio B[i,j] = D[i,j]
 
     # internal name leaks
     for sy in Tullio.SYMBOLS


### PR DESCRIPTION
This allows
```julia
julia> J = [1,3,1,1];

julia> A = [i^2 for i in 1:10];

julia> @tullio B[J[i],k] := A[k]
3×10 Array{Int64,2}:
 1  4  9  16  25  36  49  64  81  100
 0  0  0   0   0   0   0   0   0    0
 1  4  9  16  25  36  49  64  81  100

julia> @tullio B[J[i],k] += A[k]
3×10 Array{Int64,2}:
 4  16  36  64  100  144  196  256  324  400
 0   0   0   0    0    0    0    0    0    0
 2   8  18  32   50   72   98  128  162  200
```
in addition to this which already worked:
```julia
julia> @tullio C[i,k] := B[J[i],k]
4×10 Array{Int64,2}:
 4  16  36  64  100  144  196  256  324  400
 2   8  18  32   50   72   98  128  162  200
 4  16  36  64  100  144  196  256  324  400
 4  16  36  64  100  144  196  256  324  400
```