### PR TITLE
Better handling of slices f(A[i,:]) etc.

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -255,7 +255,7 @@ function parse_input(expr, store)
         error("can't understand LHS, expected A[i,j,k], got $left")
     end
     leftraw1 = tidyleftraw(primeindices(leftraw), store)
-    store.leftind = filter(i -> i isa Symbol, leftraw1) # this gives correct outer loop order
+    store.leftind = filter(i -> i isa Symbol && i != :(:), leftraw1) # this gives correct outer loop order
     store.leftraw = tidyleftraw2(leftraw1, store)
 
     isnothing(Z) && !(:newarray in store.flags) && error("can't write into an array whose name isn't given!")

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -117,6 +117,12 @@ using Tullio, Test, LinearAlgebra
     @test A == @tullio P[i'] := A[i′]
     @test [1,4,9] == @tullio Q[i'] := (i′)^2  (i' in 1:3)
 
+    # colons
+    @tullio R[i] := prod(M[:,i]) avx=false
+    @test R ≈ vec(prod(M, dims=1))
+
+    # @tullio S[:,i] := cumsum(M[:,i]) avx=false
+
     # non-numeric array
     @tullio Y[i] := (ind=i, val=A[i])
     @test Y[2] === (ind = 2, val = 4)
@@ -183,6 +189,15 @@ end
     @test W2 == W
 
     @test_throws LoadError @eval @tullio [i,j] = A[i] + 100
+
+    # colons
+    R = similar(A)
+    @tullio R[i] = sum(D[:,i]) avx=false
+    @test R == vec(sum(D, dims=1))
+
+    S = similar(D);
+    @tullio S[i,:] = cumsum(D[:,i]) avx=false
+    @test_broken S == cumsum(D, dims=1)
 
     # assignment: no loop over j
     B = zero(A);


### PR DESCRIPTION
Somewhat unexpectedly, some `mapslices`-like things already work:
```julia
julia> f(scalar, row, num) = sum(row .+ num)/scalar;

julia> s = 2; m = rand(Int8, 4,4); a = rand(1:9, 4);

julia> @tullio z[_,r] := f(s, m[r,:], a[r])
1×4 Array{Float64,2}:
 -25.5  -6.0  9.0  182.0

julia> @tullio z[_,r] := f(s, m[r,:], a[r])  threads=false verbose=true
[ Info: running KernelAbstractions CPU actor
1×4 Array{Float64,2}:
 -25.5  -6.0  9.0  182.0

julia> f.(s, eachrow(m), a)'
1×4 Adjoint{Float64,Array{Float64,1}}:
 -25.5  -6.0  9.0  182.0
```
Perhaps following https://github.com/SciML/DiffEqGPU.jl/blob/master/src/DiffEqGPU.jl they can be made to work on the GPU too. 

And perhaps there should be tests & slightly better support for such things, e.g. to avoid this:
```julia
julia> m2 = similar(m, Int);

julia> @tullio m2[:,i] = cumsum(m[i,:])
ERROR: LoadError: unable to infer range of index :
```