### PR TITLE
Better choice of tile sizes?

### DIFF
--- a/src/threads.jl
+++ b/src/threads.jl
@@ -152,9 +152,10 @@ end
 function tile_halves(fun!::F, ::Type{T}, As::Tuple, Is::Tuple, Js::Tuple, breaks::Int, keep=nothing, final=true) where {F <: Function, T}
     # keep == nothing || keep == true || error("illegal value for keep")
     # final == nothing || final == true || error("illegal value for final")
-    if breaks < 1
+    maxI, maxJ = maximumlength(Is), maximumlength(Js)
+    if maxI < 32 && maxJ < 32
         fun!(T, As..., Is..., Js..., keep, final)
-    elseif maximumlength(Is) > maximumlength(Js)
+    elseif maxI > maxJ
         I1s, I2s = cleave(Is)
         tile_halves(fun!, T, As, I1s, Js, breaks-1, keep, final)
         tile_halves(fun!, T, As, I2s, Js, breaks-1, keep, final)


### PR DESCRIPTION
#22 is a test case which benefits from much smaller tiles, and after  https://github.com/mcabbott/Tullio.jl/commit/039057b9bce504a68d2fa3ef7d0af12d99b217c9 these don't cost much. But simply changing `TILE[]` ruins matrix multiplication benchmarks.

Perhaps the tile size should go by length (of each index) not by volume (of all iterations), to satisfy both? This is (so far) a very crude way. And needs to be tried on more cases.