### PR TITLE
Allow init=0.0, and updating with any reduction

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -241,6 +241,9 @@ function parse_input(expr, store)
         else
             error("can't use *= with reduction $(store.redfun)")
         end
+    elseif @capture_(expr, left_ != right_ )
+        store.redfun in [:+, :*] && error("can't use != with reduction $(store.redfun), use += or *=")
+        push!(store.flags, :plusequals)
     else error("can't understand input, expected A[] := B[] (or with =, +=, or *=) got $expr")
     end
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -118,6 +118,7 @@ _TENSOR = Ref(true)
 function parse_options(exs...)
     opts = Dict{Symbol,Any}(
         :redfun => :+,
+        :init => TYP, # this means "auto"
         :verbose => _VERBOSE[],
         :fastmath => _FASTMATH[],
         :threads => _THREADS[],
@@ -134,6 +135,10 @@ function parse_options(exs...)
         if ex isa Expr && ex.head == :(=) && haskey(OPTS, ex.args[1])
             checklegal(ex.args[1], ex.args[2])
             opts[ex.args[1]] = ex.args[2]
+
+        # Init keyword
+        elseif ex isa Expr && ex.head == :(=) && ex.args[1] == :init
+            opts[:init] = ex.args[2]
 
         # Nograd keyword
         elseif ex isa Expr && ex.head == :(=) && ex.args[1] == :nograd
@@ -176,6 +181,7 @@ function parse_options(exs...)
         _TENSOR[] = opts[:tensor]
     end
     (redfun=opts[:redfun],
+        init=opts[:init], # surely there is a tidier way...
         verbose=opts[:verbose],
         fastmath=opts[:fastmath],
         threads=opts[:threads],
@@ -695,12 +701,16 @@ function action_functions(store)
 
     #===== constructing loops =====#
 
-    init = store.redfun == :* ? :(one($TYP)) :
+    init = if store.init == TYP # then auto
+        store.redfun == :* ? :(one($TYP)) :
         store.redfun == :max ? :(typemin($TYP)) :
         store.redfun == :min ? :(typemax($TYP)) :
         store.redfun == :& ? :(true) :
         store.redfun == :| ? :(false) :
         :(zero($TYP))
+    else
+        store.init
+    end
 
     # Right now this would allow *= only with reduction * too. Could separate them:
     # acc=0; acc = acc + rhs; Z[i] = ifelse(keep, acc, Z[i] * acc)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -59,6 +59,11 @@ macro capture_(ex, pat::Expr)
         _endswithone(pat.args[1]) && _endswithone(pat.args[2]) # :( A_ += B_ )
         _symbolone(pat.args[1]), _symbolone(pat.args[2])
 
+    elseif pat.head == :call  && length(pat.args)==3 && pat.args[1] == :!= &&
+        _endswithone(pat.args[2]) && _endswithone(pat.args[3]) # :( A_ != B_ )
+        H = QuoteNode(pat.args[1])
+        _symbolone(pat.args[2]), _symbolone(pat.args[3])
+
     elseif pat.head == :vect && _endswithtwo(pat.args[1]) # :( [ijk__] )
         _symboltwo(pat.args[1]), gensym(:ignore)
 
@@ -109,6 +114,12 @@ _trymatch(ex::Expr, pat::Val{:call}) =
 _trymatch(ex::Expr, pat::Union{Val{:(=)}, Val{:(:=)}, Val{:(+=)}, Val{:(-=)}, Val{:(*=)}, Val{:(/=)}}) =
     if ex.head === _getvalue(pat)
         ex.args[1], ex.args[2]
+    else
+        nothing
+    end
+_trymatch(ex::Expr, pat::Val{:!=}) =
+    if ex.head === :call && length(ex.args) == 3 && ex.args[1] == :!=
+        ex.args[2], ex.args[3]
     else
         nothing
     end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -395,6 +395,13 @@ end
     M = rand(1:9, 4,5)
     @test vec(prod(M,dims=2)) == @tullio (*) B[i] := M[i,j]
 
+    # != generalises +=, *=
+    C = copy(A)
+    @tullio (max) C[i] != 5i
+    @test C == max.(5:5:50, A)
+    @test_throws Exception @eval @tullio A[i] != A[i]
+    @test_throws Exception @eval @tullio (*) A[i] != A[i]
+
     # more dimensions
     Q = rand(1:10^3, 4,5,6)
     @test vec(maximum(Q,dims=(2,3))) == @tullio (max) R[i] := Q[i,j,k]

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -402,6 +402,11 @@ end
     @test_throws Exception @eval @tullio A[i] != A[i]
     @test_throws Exception @eval @tullio (*) A[i] != A[i]
 
+    # initialisation
+    @test 200 == @tullio (max) m := A[i] init=200
+    @tullio (max) C[i] := i^2   (i in 1:10, j in 1:1)  init=50.0
+    @test C == max.(50, A)
+
     # more dimensions
     Q = rand(1:10^3, 4,5,6)
     @test vec(maximum(Q,dims=(2,3))) == @tullio (max) R[i] := Q[i,j,k]


### PR DESCRIPTION
Closes #24, by allowing
```julia
@tullio (max) A[i] := i^2   (i in 1:10, j in 1:1)  init=33  # instead of typemin(Int)

@tullio (max) A[i] != i^3   # like +=, this continues from values in A
```
* Perhaps `!=` (! for mutation) is too weird or too subtle?
* Without trivial reduction index `j in 1:1`, the first line would never use `init`. Should it? Or should it be an error?