### PR TITLE
Simplify the generated code in `ex_nored`, and use first() to collect scalar output instead of sum()

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -780,8 +780,8 @@ function action_functions(store)
             push!(store.outex, :($(store.leftarray) = $ex ))
             return :($(store.leftarray) = $ex )
         elseif :scalar in store.flags
-             push!(store.outex, :($(store.leftscalar) = sum($ex)))
-             return :($(store.leftscalar) = sum($ex))
+             push!(store.outex, :($(store.leftscalar) = first($ex)))
+             return :($(store.leftscalar) = first($ex))
         else # case of [i,j] := ... with no name given
             # push!(store.outex, ex)
             return ex

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -703,12 +703,7 @@ function action_functions(store)
     # acc=0; acc = acc + rhs; Z[i] = ifelse(keep, acc, Z[i] * acc)
     # But then keep=true can't be used for blocking, which wants to continue the same as acc.
 
-    ex_init = if :plusequals in store.flags && !all(isa.(store.leftraw,Int))
-        :( $ACC = $ZED[$(store.leftraw...)] ) # for += init is needed only for scalar output. And at present only outputs like a,a[1],a[1,2,1] will seen scalar and enter thread_scalar()
-    else
-        :( $ACC = ifelse(isnothing($KEEP), $init, $ZED[$(store.leftraw...)]) )
-    end
-#     ex_init = :( $ACC = ifelse(isnothing($KEEP), $init, $ZED[$(store.leftraw...)]) )
+    ex_init = :( $ACC = ifelse(isnothing($KEEP), $init, $ZED[$(store.leftraw...)]) )
     # ex_init = :( $ACC = isnothing($KEEP) ? $init : $ZED[$(store.leftraw...)] ) # more allocations with @avx, not sure why
 
     ex_iter = :( $ACC = $(store.redfun)($ACC, $(store.right) ) )

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -704,7 +704,7 @@ function action_functions(store)
     # But then keep=true can't be used for blocking, which wants to continue the same as acc.
 
     ex_init = if :plusequals in store.flags && !all(isa.(store.leftraw,Int))
-        :( $ACC = $ZED[$(store.leftraw...)] ) # for += init is need only for scalar output. And at present only a,a[1],a[1,2,1] will seen scalar and enter thread_scalar()
+        :( $ACC = $ZED[$(store.leftraw...)] ) # for += init is needed only for scalar output. And at present only outputs like a,a[1],a[1,2,1] will seen scalar and enter thread_scalar()
     else
         :( $ACC = ifelse(isnothing($KEEP), $init, $ZED[$(store.leftraw...)]) )
     end
@@ -720,18 +720,10 @@ function action_functions(store)
         :( $ZED[$(store.leftraw...)] = ifelse(isnothing($FINAL), $ACC, $(store.finaliser)($ACC)) )
     end
 
-    ex_nored = if :plusequals in store.flags # meaning always keep = true
-        if store.finaliser == :identity
-            :( $ZED[$(store.leftraw...)] =  $(store.redfun)($ZED[$(store.leftraw...)] ,$(store.right))  )
-        else
-            :( $ZED[$(store.leftraw...)] =  $(store.finaliser)($(store.redfun)($ZED[$(store.leftraw...)] ,$(store.right))) )
-        end
+    ex_nored = if :plusequals in store.flags # meaning always keep = true and final = true, since there's no branch, no need to reduce :identity
+        :( $ZED[$(store.leftraw...)] =  $(store.finaliser)($(store.redfun)($ZED[$(store.leftraw...)] ,$(store.right))) )
     else
-        if store.finaliser == :identity
-            :( $ZED[$(store.leftraw...)] =  $(store.right) )
-        else
-            :( $ZED[$(store.leftraw...)] =  $(store.finaliser)($(store.right)) )
-        end
+        :( $ZED[$(store.leftraw...)] =  $(store.finaliser)($(store.right)) )
     end
 
     if isempty(store.redind)

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -384,7 +384,7 @@ end
     @test minimum(A) == @tullio (min) m := float(A[i]) # fails with @avx
 
     @test true == @tullio (&) p := A[i] > 0
-    @test_broken true === @tullio (&) p := A[i] > 0 # sum([true]) isa Int
+    @test true === @tullio (&) p := A[i] > 0 # sum([true]) isa Int
     @test true == @tullio (|) q := A[i] > 50
 
     # in-place


### PR DESCRIPTION
1. `ex_init`
~~At present, Tullio only use the init under 2 case, multi-thread reduction towards scalar, and `:=`/`=`.
So, if we found there's a `:plusequals` in `store.flags`, and the output is not be treated as a scalar(not a, a[1],a[1,2,1]), the ifelse call could be removed.~~

2. `ex_nored`
Since there's no axes for reduction, the value of KEEP won't change. 
I think the branch could be omitted, and it seems unnecessary to reduce indentity call here.

3. sum([true]) --> first([true])

