### PR TITLE
Better scalar reductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ Here the macro cannot infer the range of the output's indices `x,y`, so they mus
 It knows that it should not sum over indices `i,j`, but since it can't be sure of their ranges, it will not add `@inbounds` in such cases.
 It will also not be able to take a symbolic derivative here, but dual numbers will work fine.
 
-Pipe operators `|>` and `<|` indicate functions to be performed *outside* the sum, for example:
+Pipe operators `|>` or `<|` indicate functions to be performed *outside* the sum, for example:
 
 ```julia
 @tullio lse[j] := log <| exp(mat[i,j])   # vec(log.(sum(exp.(mat), dims=1))) 
 ```
 
 The option `@tullio verbose=true` will cause it to print index ranges, symbolic derivatives,
-and notices when it is unable to use the packages mentioned above.
+and notices when it is unable to use the packages mentioned above. 
+And `verbose=2` will print everything.
 
 <details><summary><b>Notation</b></summary>
 
@@ -85,9 +86,9 @@ using FFTW # Functions of the indices are OK:
 S = [0,1,0,0, 0,0,0,0]
 fft(S) ≈ @tullio F[k] := S[x] * exp(-im*pi/8 * (k-1) * x)  (k ∈ axes(S,1))
 
-# Finalisers <| or |> are applied after sum:
-@tullio N2[j] := sqrt <| M[i,j]^2   # N2 ≈ map(norm, eachcol(M)) 
-@tullio n3 := A[i]^3  |> (_)^(1/3)  # n3 ≈ norm(A,3), with _ anon. func.
+# Finalisers <| or |> are applied after sum (the two are equivalent)
+@tullio N2[j] := sqrt <| M[i,j]^2     # N2 ≈ map(norm, eachcol(M)) 
+@tullio n3[_] := A[i]^3  |> (_)^(1/3) # n3[1] ≈ norm(A,3), with _ anon. func.
 
 # Reduction over any function:
 @tullio (*) P[i] := A[i+k]  (k in 0:2) # product
@@ -117,7 +118,7 @@ bmm_rev(A, B) = @tullio C[i,k,b] := A[i,j,b] * B[b,k,j]  # (sum over j)
 A = randn(20,30,500); B = randn(500,40,30);
 bmm_rev(A, B) ≈ NNlib.batched_mul(A, permutedims(B, (3,2,1))) # true
 
-@btime bmm_rev($A, $B); # 317.526 μs μs, same speed as un-permuted bmm
+@btime bmm_rev($A, $B); # 317.526 μs, same speed as un-permuted bmm
 @btime NNlib.batched_mul($A, permutedims($B, (3,2,1))); # 1.478 ms, with MKL
 
 # Complete reduction, without first materialising X .* log.(Y')
@@ -207,7 +208,7 @@ The default setting is:
 * `init=0.0` gives the initial value for reductions. For `+`, `*`, `min`, `min`, `&`, `|` it has sensible defaults, for other reductions uses zero.
 
 Implicit:
-* Indices without shifts must have the same range everywhere they appear, but those with shifts (even `A[i+0]`) run over the inersection of possible ranges.
+* Indices without shifts must have the same range everywhere they appear, but those with shifts (even `A[i+0]`) run over the intersection of possible ranges.
 * Shifted output indices must start at 1, unless `OffsetArrays` is visible in the calling module.
 * The use of `@avx`, and the calculation of gradients, are switched off by sufficiently complex syntax (such as arrays of arrays). 
 * Gradient hooks are attached for any or all of `ReverseDiff`, `Tracker` & `Zygote`. These packages need not be loaded when the macro is run.
@@ -230,7 +231,7 @@ Back-end friends & relatives:
 
 * [Gaius.jl](https://github.com/MasonProtter/Gaius.jl) and [PaddedMatrices.jl](https://github.com/chriselrod/PaddedMatrices.jl) build on that.
 
-* [GPUifyLoops.jl](https://github.com/vchuravy/GPUifyLoops.jl) and [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl) generate GPU-compatable kernels.
+* [GPUifyLoops.jl](https://github.com/vchuravy/GPUifyLoops.jl) and [KernelAbstractions.jl](https://github.com/JuliaGPU/KernelAbstractions.jl) generate GPU-compatible kernels.
 
 * [ThreadsX.jl](https://github.com/tkf/ThreadsX.jl) does threaded reductions, and much else.
 
@@ -238,7 +239,7 @@ Back-end friends & relatives:
 
 Front-end near-lookalikes:
 
-* [Einsum.jl](https://github.com/ahwillia/Einsum.jl) makes simple loops. See [tests/einsum.jl](https://github.com/mcabbott/Tullio.jl/blob/master/test/einsum.jl) where `using Tullio: @einsum` is an almost-seamless replaceement.
+* [Einsum.jl](https://github.com/ahwillia/Einsum.jl) makes simple loops. See [tests/einsum.jl](https://github.com/mcabbott/Tullio.jl/blob/master/test/einsum.jl) where `using Tullio: @einsum` is an almost-seamless replacement.
 
 * [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl) and [OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl) identify patterns on which they can call various basic operations.
 

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -76,9 +76,6 @@ end
 
 #========== CuArrays ==========#
 
-@inline getonly(a::AbstractArray) = first(a) # just avoid first(::CuArray)
-@inline setonly!(a::AbstractArray, val) = setindex!(a, val, 1)
-
 using Requires
 
 @init @require CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba" begin
@@ -93,20 +90,7 @@ using Requires
         As::Tuple, Is::Tuple, Js::Tuple, block=0) where {F<:Function, T<:CuArray} =
         fun!(T, As..., Is..., Js...,)
 
-    function Tullio.getonly(a::CuArray) # @allowscalar first(a)
-        prev = GPUArrays.scalar_allowed[]
-        GPUArrays.scalar_allowed[] = GPUArrays.ScalarAllowed
-        res = first(a)
-        GPUArrays.scalar_allowed[] = prev
-        res
-    end
-    function Tullio.setonly!(a::CuArray, val) # @allowscalar a[1] = val
-        prev = GPUArrays.scalar_allowed[]
-        GPUArrays.scalar_allowed[] = GPUArrays.ScalarAllowed
-        res = setindex!(a, val, 1)
-        GPUArrays.scalar_allowed[] = prev
-        res
-    end
+    # Tullio.thread_scalar ... ought to work? Was never fast.
 
     # Base.extrema(a::CuArray{<:Integer}) = minimum(a), maximum(a)
 

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -33,17 +33,6 @@ end
 Base.size(::OneBox) = (1,)
 Base.getindex(o::OneBox, i::Integer...) = o.val
 
-# struct TypeBox{T} <: AbstractVector{T}
-#     TypeBox(::Type{T}) where {T} = new{T}()
-#     TypeBox(x) = new{typeof(x)}()
-# end
-# Base.size(::TypeBox) = (1,)
-# Base.getindex(o::TypeBox, i::Integer...) = (@error "getindex(TypeBox)"; zero(eltype(o)))
-# Base.print_matrix(io::IO, o::TypeBox) =
-#     hasmethod(zero, Tuple{eltype(o)}) ?
-#         Base.print_matrix(io, Array(o)) :
-#         print(io, " zero() not defined for this type")
-
 #========== gradient hooks ==========#
 # Macros like @adjoint need to be hidden behind include(), it seems:
 
@@ -54,19 +43,6 @@ using Requires
 @init @require Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include("grad/tracker.jl")
 
 @init @require ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267" include("grad/reverse.jl")
-
-#=
-@init @requite Yota = "cd998857-8626-517d-b929-70ad188a48f0" begin
-    using .Yota
-
-#     for (n,A) in enumerate(store.arrays)
-#         push!(evalex, quote
-#             Yota.@diffrule  $make($(store.arrays...), $(store.scalars...))  $A  getindex($∇make(dy, $(store.arrays...), $(store.scalars...)), $n)
-#         end)
-#     end
-
-end
-=#
 
 #========== vectorised gradients ==========#
 
@@ -115,9 +91,6 @@ using Requires
         fun!(T, As..., Is..., Js...,)
 
     # Tullio.thread_scalar ... ought to work? Was never fast.
-
-    # Base.extrema(a::CuArray{<:Integer}) = minimum(a), maximum(a)
-
 end
 
 #========== storage unwrapper ==========#

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -23,11 +23,9 @@ end
 
 """
     OneBox(val)
-    TypeBox(T)
 
-Trivial 1-element vectors, used for scalar redutcions,
-to pass the eltype to `$ACT!(AT, ::AbstractArray{$TYP}, ...)`,
-and the initial element for scalar `+=`.
+Trivial 1-element vector, used for scalar redutcions,
+to pass the eltype to `∇$ACT!(AT, 𝛥A, ::AbstractArray{$TYP}, ...)`
 """
 struct OneBox{T} <: AbstractVector{T}
     val::T
@@ -35,16 +33,16 @@ end
 Base.size(::OneBox) = (1,)
 Base.getindex(o::OneBox, i::Integer...) = o.val
 
-struct TypeBox{T} <: AbstractVector{T}
-    TypeBox(::Type{T}) where {T} = new{T}()
-    TypeBox(x) = new{typeof(x)}()
-end
-Base.size(::TypeBox) = (1,)
-Base.getindex(o::TypeBox, i::Integer...) = zero(eltype(o))
-Base.print_matrix(io::IO, o::TypeBox) =
-    hasmethod(zero, Tuple{eltype(o)}) ?
-        Base.print_matrix(io, Array(o)) :
-        print(io, " zero() not defined for this type")
+# struct TypeBox{T} <: AbstractVector{T}
+#     TypeBox(::Type{T}) where {T} = new{T}()
+#     TypeBox(x) = new{typeof(x)}()
+# end
+# Base.size(::TypeBox) = (1,)
+# Base.getindex(o::TypeBox, i::Integer...) = (@error "getindex(TypeBox)"; zero(eltype(o)))
+# Base.print_matrix(io::IO, o::TypeBox) =
+#     hasmethod(zero, Tuple{eltype(o)}) ?
+#         Base.print_matrix(io, Array(o)) :
+#         print(io, " zero() not defined for this type")
 
 #========== gradient hooks ==========#
 # Macros like @adjoint need to be hidden behind include(), it seems:

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -19,6 +19,32 @@ end
 
 (ev::Eval)(args...) = ev.fwd(args...)
 
+#========== scalar struct ==========#
+
+"""
+    OneBox(val)
+    TypeBox(T)
+
+Trivial 1-element vectors, used for scalar redutcions,
+to pass the eltype to `$ACT!(AT, ::AbstractArray{$TYP}, ...)`,
+and the initial element for scalar `+=`.
+"""
+struct OneBox{T} <: AbstractVector{T}
+    val::T
+end
+Base.size(::OneBox) = (1,)
+Base.getindex(o::OneBox, i::Integer...) = o.val
+
+struct TypeBox{T} <: AbstractVector{T}
+    TypeBox(::Type{T}) where {T} = new{T}()
+    TypeBox(x) = new{typeof(x)}()
+end
+Base.size(::TypeBox) = (1,)
+Base.getindex(o::TypeBox, i::Integer...) = zero(eltype(o))
+Base.print_matrix(io::IO, o::TypeBox) =
+    hasmethod(zero, Tuple{eltype(o)}) ?
+        Base.print_matrix(io, Array(o)) :
+        print(io, " zero() not defined for this type")
 
 #========== gradient hooks ==========#
 # Macros like @adjoint need to be hidden behind include(), it seems:

--- a/src/forward.jl
+++ b/src/forward.jl
@@ -35,7 +35,7 @@ function insert_forward_gradient(axislist, store)
         # vcat(gradarrays, gradscalars, :($dZ::AbstractArray{$TYP}), store.arrays, store.scalars, axislist),
         :(($(defineepsilons...);)), store.sharedind, nothing, nonshared, ex_iter, nothing, store, "(gradient using ForwardDiff)")
 
-    if isdefined(store.mod, :Zygote)
+    if isdefined(store.mod, :Zygote) && !(:scalar in store.flags)
         ex_iter2 = fillarrayreplace(ex_iter, dZ)
         ex_value = :($(Symbol(dZ, :_value)) = $dZ.value)
 

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1120,7 +1120,7 @@ function backward_definitions(store)
         store.threads==true ? (BLOCK[] ÷ store.cost) :
         store.threads
     input, acton = if :scalar in store.flags
-        :($dZ::$TYP), :($dZ:$dZ) # a hack to minimise changes to Act!, for now! ??
+        :($dZ::$TYP), :( $OneBox($dZ) ) # a hack to minimise changes to Act!, for now! ??
     else
         :($dZ::AbstractArray{$TYP}), dZ
     end

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -44,7 +44,7 @@ function _tullio(exs...; mod=Main)
 
     if opts.tensor && opts.redfun == :+ && isdefined(mod, :TensorOperations) && opts.grad != :Dual
         res = try_tensor(ex, ranges, DotDict(;mod = mod, opts...,
-            arrays = Symbol[], indices = [], scalars = Symbol[]))
+            flags = Set{Symbol}(), arrays = Symbol[], indices = [], scalars = Symbol[]))
         if res != nothing # then forward & backward both handled by try_tensor
             return Expr(:block, res...) |> esc
         end

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -705,9 +705,9 @@ function output_array(store)
 
         simex = if :scalar in store.flags && :plusequals in store.flags
             # Deal with scalar += now, by writing into array, later read it out:
-            :( $(store.leftscalar):$(store.leftscalar) )
+            :( $OneBox($(store.leftscalar)) )
         elseif :scalar in store.flags # no longer writes into this, but still needs something!
-            :( zero($TYP):zero($TYP) )
+            :( $TypeBox($TYP) )
         elseif isempty(store.arrays)
             # :( zeros($TYP, tuple($(outaxes...))) ) # Array{T} doesn't accept ranges... but zero() doesn't accept things like  @tullio [i,j] := (i,j)  i ∈ 2:3, j ∈ 4:5
             :( similar(1:0, $TYP, tuple($(outaxes...))) )

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -72,7 +72,7 @@ function insert_symbolic_gradient(axislist, store)
         # vcat(gradarrays, gradscalars, :($dZ::AbstractArray{$TYP}), store.arrays, store.scalars, axislist),
         nothing, out_ind, ex_pre, in_ind, ex_body, ex_post, store, "(symbolic gradient)")
 
-    if isdefined(store.mod, :Zygote) # special case for FillArrays
+    if isdefined(store.mod, :Zygote) && !(:scalar in store.flags) # special case for FillArrays
         ex_body2 = fillarrayreplace(ex_body, dZ)
         ex_pre2 = fillarrayreplace(ex_pre, dZ)
         ex_value = :($(Symbol(dZ, :_value)) = $dZ.value) # @avx likes this outside the loop

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -182,6 +182,13 @@ end
     con14(x) = @tullio K[i,j] := r3399[a,b,j,k] * x[b,c,k,i] * r33[a,c]
     @test gradtest(con14, (3,3,9,9))
 
+    ## scalar -- one with :=, one without
+    sc1(x) = @tullio s = r22[b,β] * x[a,b,c] * r312[c,a,β]
+    @test gradtest(sc1, (1,2,3))
+
+    sc2(x) = @tullio s := x[γ,c] * r3399[c,γ,i,i]
+    @test gradtest(sc2, (3,3))
+
 end
 
 if Tullio._GRAD[] != :Dual

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -17,6 +17,10 @@ r100 = randn(100)
 g_fd = ForwardDiff.gradient(x -> sum(sin, g2(x)), r100)
 @test g_fd ≈ _gradient(x -> sum(sin, g2(x)), r100)[1]
 
+# scalar output
+s2(x) = @tullio s := exp(x[i]) / x[j]
+@test _gradient(s2, r100)[1] ≈ ForwardDiff.gradient(s2, r100)
+
 # two arrays, and a sum
 h2(x,y) = @tullio z[i] := x[i,j] + y[j,i]
 @test _gradient(sum∘h2, rand(2,3), rand(3,2)) == (ones(2,3), ones(3,2))

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -386,7 +386,7 @@ end
     @test minimum(A) == @tullio (min) m := float(A[i]) # fails with @avx
 
     @test true == @tullio (&) p := A[i] > 0
-    @test_broken true === @tullio (&) p := A[i] > 0 # not sure why now ??
+    @test true === @tullio (&) p := A[i] > 0
     @test true == @tullio (|) q := A[i] > 50
 
     # in-place


### PR DESCRIPTION
Aims to fix #29, whose example now reads:
```julia
julia> using LinearAlgebra, Tullio

julia> v = rand(10);

julia> td(v,w) = @tullio d := v[i] * w[i]

julia> @btime td($v, $v)  # was 2 μs, still not zero alloc.
  36.549 ns (1 allocation: 16 bytes)
3.1122375955695656

julia> @btime dot($v, $v) # 20 ns
  19.783 ns (0 allocations: 0 bytes)
3.1122375955695665

julia> ts(v) = @tullio s := v[i]

julia> @btime ts($v)  # was 2 μs
  8.935 ns (0 allocations: 0 bytes)
4.7306314044350515

julia> @btime sum($v) # 4 ns
  4.758 ns (0 allocations: 0 bytes)
4.7306314044350515
```
~~Won't work with complex numbers yet. Doesn't address `@tensor` yet.~~ Still has more fake 1-vectors floating around than I'd like. 