### PR TITLE
Add mod, clamp, and a magic underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Tullio is a very flexible einsum macro. It understands many array operations written in index notation, for example:
 
 ```julia
-@tullio M[x,y,c] := N[x+i, y+j,c] * K[i,j]     # sum over i,j, and create M
+@tullio M[x+_,y+_,c] := N[x+i, y+j,c] * K[i,j] # sum over i,j, and create M
 
 @tullio S[x] = P[x,y] * log(Q[x,y] / R[y])     # sum over y, and write into S
 
@@ -77,10 +77,15 @@ A = [abs2(i - 11) for i in 1:21]
 
 using OffsetArrays # Convolve a filter:
 K = OffsetArray([1,-1,2,-1,1], -2:2)
-@tullio C[i] := A[i+j] * K[j]  # j ∈ -2:2 implies i ∈ 3:19
+@tullio C[i] := A[i+j] * K[j]    # j ∈ -2:2 implies i ∈ 3:19
 
 # Index by the values in K
 @tullio D[i,j] := A[2K[j]+i] ÷ K[j] # extrema(K)==(-1,2) implies i ∈ 3:17
+
+# Wrapped & padded:
+@tullio M[i,j] := A[mod(i+j)]  (j in 1:15, i in 1:15)   # wraps around, mod(i+j, axes(A,1))
+@tullio M[i,j] := A[clamp(i+j)]  (j in 1:15, i in 1:15) # instead repeats "100"
+@tullio M[i+_,j] := A[pad(i+j, 3)]  (j in 1:15)         # fills with zeros
 
 using FFTW # Functions of the indices are OK:
 S = [0,1,0,0, 0,0,0,0]

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -455,9 +455,9 @@ padmodclamp(A, inds, store) = begin
             cond = :($cond & $c2)
         end
         if store.padkeyword == TYP # default
-            return :(ifelse($cond, @inbounds($Aex), zero(eltype($A))))
+            return :($cond ? $Aex : zero(eltype($A)))
         else
-            return :(ifelse($cond, @inbounds($Aex), convert(eltype($A), $(store.padkeyword))))
+            return :($cond ? $Aex : convert(eltype($A), $(store.padkeyword)))
         end
     end
 end

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -432,6 +432,11 @@ modindices(A, inds) = map(enumerate(inds)) do (d,iraw)
         elseif ex.args[1] == :clamp && length(ex.args) == 2
             i = ex.args[2]
             return :(clamp($i, first(axes($A,$d)), last(axes($A,$d))))
+        elseif ex.args[1] == :pad && length(ex.args) >= 3
+            # for now the only difference from clamp is range inference
+            @warn "padding is experimental!" ex maxlog=3
+            i = ex.args[2]
+            return :(clamp($i, first(axes($A,$d)), last(axes($A,$d))))
         end
         ex
     end

--- a/src/shifts.jl
+++ b/src/shifts.jl
@@ -98,7 +98,9 @@ function range_expr_walk(r::Expr, ex::Expr, con=[])
         return (:($extremerange($A)),nothing)
     end
     ex.head == :call || throw("not sure what to do with $ex")
-    if length(ex.args) == 2
+    if ex.args[1] in (:mod, :clamp, :mod1)
+        return range_expr_walk(nothing, ex.args[2])
+    elseif length(ex.args) == 2
         op, a = ex.args
         if op == :+
             return range_expr_walk(r, a)
@@ -160,6 +162,49 @@ is_const(ex::Expr) = begin
     end
     false
 end
+
+"""
+    range_expr_walk(nothing, :(i+j))
+
+Special case for finding what indices appear inside `A[mod(i+j)]` etc,
+for which no ranges are inferred.
+"""
+range_expr_walk(::Nothing, s::Symbol) = nothing, s
+range_expr_walk(::Nothing, ex::Expr) =
+    if ex.head == :ref
+        return nothing, nothing
+    elseif ex.head == :call
+        if length(ex.args) == 2
+            op, a = ex.args
+            if op in (:+, :-)
+                return range_expr_walk(nothing, a)
+            end
+        elseif length(ex.args) == 3
+            op, a, b = ex.args
+            if op in (:+, :-)
+                is_const(a) && return range_expr_walk(nothing, b)
+                is_const(b) && return range_expr_walk(nothing, a)
+                range_a, i_a = range_expr_walk(nothing, a)
+                range_b, i_b = range_expr_walk(nothing, b)
+                return (range_a, range_b), (i_a, i_b)
+            elseif op == :*
+                is_const(a) && return range_expr_walk(nothing, b)
+                is_const(b) && return range_expr_walk(nothing, a)
+            elseif op == :÷
+                is_const(b) && return range_expr_walk(nothing, a)
+            end
+        elseif length(ex.args) > 3
+            op, a, b, c = ex.args[1:4]
+            ds = ex.args[5:end]
+            if op == :+
+                is_const(a) && return range_expr_walk(nothing, :(+($b, $c, $(ds...))))
+                is_const(b) && return range_expr_walk(nothing, :(+($a, $c, $(ds...))))
+                is_const(c) && return range_expr_walk(nothing, :(+($a, $b, $(ds...))))
+            end
+        end
+    else
+        throw("not sure what to do with $ex, in the end")
+    end
 
 """
     range_expr_walk(:(axes(A,1)), :(i=j)) -> :(axes(A, :i)), :j

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -280,6 +280,15 @@ if Tullio._GRAD[] != :Dual
 
     end
 
+    @testset "mod, clamp, pad" begin
+        fmod(x) = @tullio y[i] := x[mod(i)]  i in 1:5
+        fclamp(x) = @tullio y[i] := x[clamp(i)]  i in 1:5
+        fpad(x) = @tullio y[i] := x[pad(i-2,2)]
+        @test _gradient(sum∘fmod, ones(3))[1] == [2,2,1]
+        @test _gradient(sum∘fclamp, ones(3))[1] == [1,1,3]
+        @test _gradient(sum∘fpad, ones(3))[1] == [1,1,1]
+    end
+
     @testset "finalisers" begin
 
         norm2(m) = @tullio n[i] := m[i,j]^2 |> sqrt

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -393,6 +393,11 @@ end
     @test [4,16,36,64,100,4] == @tullio E[i] := A[mod(2i)]  i in 1:6
     @test [9,25,49,81,1,9] == @tullio E[i] := A[mod(2i+1, 1:10)]  i in 1:6
 
+    # pairconstraints
+    @tullio F[i] := A[mod(i+k)] * ones(3)[k]  (i in axes(A,1))
+    @test F[end] == 1 + 2^2 + 3^2
+    @tullio F[i] = A[clamp(i+k)] * ones(7)[k]
+
     # unable to infer range
     @test_throws LoadError @eval @tullio F[i] := A[mod(i+1)]
     # can't use index mod(i) on LHS

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -413,6 +413,11 @@ end
     @tullio H[i+_,j+_] := M[pad(i,2), pad(j,3)]  pad=1
     @test H == [trues(2,10); trues(3,3) M trues(3,3); trues(2,10)]
 
+    # pad keyword
+    @tullio J[i,i] := sqrt(A[i])  pad=-1
+    @test J[3,4] == -1
+    @test diag(J) == 1:10
+
     # unable to infer range
     @test_throws LoadError @eval @tullio F[i] := A[mod(i+1)]
     @test_throws LoadError @eval @tullio F[i] := A[pad(2i)]
@@ -422,6 +427,7 @@ end
     @test_throws LoadError @eval @tullio F[i] := A[clamp(i)+1]
     # eltype of pad doesn't fit
     @test_throws InexactError @tullio H[i] := A[pad(i,3)]  pad=im
+    @test_throws InexactError @tullio J[i,i] := A[i]  pad=im
 end
 
 @testset "other reductions" begin

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -393,12 +393,11 @@ end
 
     @test vcat(B,B) == @tullio C[i] := B[mod(i)]  i in 1:10
     @test vcat(B, fill(B[end],5)) == @tullio D[i] := min(A[i], B[clamp(i)])
-
     @test [4,16,36,64,100,4] == @tullio E[i] := A[mod(2i)]  i in 1:6
-    @test [9,25,49,81,1,9] == @tullio E[i] := A[mod(2i+1, 1:10)]  i in 1:6
 
     @test vcat(zeros(5), B, zeros(5)) == @tullio C[i] := B[pad(i-5,5)]
     @test vcat(zeros(2), A, zeros(3)) == @tullio D[i+_] := A[pad(i,2,3)]
+    @test vcat(A, zeros(10)) == @tullio E[i] := A[pad(i)]  i in 1:20
 
     # pairconstraints
     @tullio F[i] := A[mod(i+k)] * ones(3)[k]  (i in axes(A,1))
@@ -411,10 +410,11 @@ end
 
     # unable to infer range
     @test_throws LoadError @eval @tullio F[i] := A[mod(i+1)]
+    @test_throws LoadError @eval @tullio F[i] := A[pad(2i)]
     # can't use index mod(i) on LHS
     @test_throws LoadError @eval @tullio G[mod(i)] := A[i]
     # eltype of pad doesn't fit
-    @test_throws InexactError @tullio H[i] := A[pad(i,3)]  pad=im
+    @test_throws InexactError @tullio H[i] := A[pad(i,3)]  pad=im # ?? fails for other reasons without OffsetArrays, "no method matching similar(::Array{Int64,1}, ::Type{Int64}, ::Tuple{UnitRange{Int64}})"
 
 end
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -406,16 +406,22 @@ end
 
     @tullio G[i] := A[pad(i+k, 4)] * ones(3)[k]  pad=100
     @test axes(G,1) == -4:11
-    @test G[begin] == G[end] == 300
+    @test G[-4] == G[11] == 300
+
+    # matrix
+    M = rand(Int8, 3,4)
+    @tullio H[i+_,j+_] := M[pad(i,2), pad(j,3)]  pad=1
+    @test H == [trues(2,10); trues(3,3) M trues(3,3); trues(2,10)]
 
     # unable to infer range
     @test_throws LoadError @eval @tullio F[i] := A[mod(i+1)]
     @test_throws LoadError @eval @tullio F[i] := A[pad(2i)]
     # can't use index mod(i) on LHS
     @test_throws LoadError @eval @tullio G[mod(i)] := A[i]
+    # not sure what to do with clamp(i), sorry
+    @test_throws LoadError @eval @tullio F[i] := A[clamp(i)+1]
     # eltype of pad doesn't fit
-    @test_throws InexactError @tullio H[i] := A[pad(i,3)]  pad=im # ?? fails for other reasons without OffsetArrays, "no method matching similar(::Array{Int64,1}, ::Type{Int64}, ::Tuple{UnitRange{Int64}})"
-
+    @test_throws InexactError @tullio H[i] := A[pad(i,3)]  pad=im
 end
 
 @testset "other reductions" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -68,9 +68,6 @@ using Tullio: range_expr_walk, divrange, minusrange, subranges, addranges
             @test issubset(sort(f.(eval(rex))), r)
         end
 
-        @test range_expr_walk(:($r .+ 0), :(mod(i))) == (nothing, :i)
-        @test range_expr_walk(:($r .+ 0), :(clamp(2i+1))) == (nothing, :i)
-
         rex, _ = range_expr_walk(:($r .+ 0), :(pad(i,2)))
         @test extrema(eval(rex)) == (first(r)-2, last(r)+2)
         rex, _ = range_expr_walk(:($r .+ 0), :(pad(i+1,2,5)))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -67,6 +67,18 @@ using Tullio: range_expr_walk, divrange, minusrange, subranges, addranges
             rex, i = range_expr_walk(:($r .+ 0), ex)
             @test issubset(sort(f.(eval(rex))), r)
         end
+
+        @test range_expr_walk(:($r .+ 0), :(mod(i))) == (nothing, :i)
+        @test range_expr_walk(:($r .+ 0), :(clamp(2i+1))) == (nothing, :i)
+
+        rex, _ = range_expr_walk(:($r .+ 0), :(pad(i,2)))
+        @test extrema(eval(rex)) == (first(r)-2, last(r)+2)
+        rex, _ = range_expr_walk(:($r .+ 0), :(pad(i+1,2,5)))
+        @test extrema(eval(rex)) == (first(r)-1-2, last(r)-1+5)
+
+        @test range_expr_walk(:($r .+ 0), :(i+j))[2] == (:i, :j) # weak test!
+
+        # range adjusting functions
         @test minusrange(r) == divrange(r, -1)
 
         @test issubset(subranges(r, 1:3) .+ 1, r)


### PR DESCRIPTION
This allows, first,
```julia
@tullio A[i] := B[mod(i+k)] * C[k]  (i in axes(B,1))
@tullio A[i] = B[clamp(i+k)] * C[k]
```
meaning `mod(...) == mod(..., axes(B,1))`, and allowing any range for the indices inside the `mod`. It's a bit inefficient to `clamp` at every iteration, rather than separating out lo/mid/hi parts of the axis.

And second, 
```julia
@tullio A[i+_] := B[i+k] * C[k]
```
where `_` is a shift computed to ensure `axes(A,1) isa Base.OneTo`, while `i in 0:N` if B & C are ordinary Arrays.