### PR TITLE
Add tests for LoopVectorization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.4' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: julia
 os:
   - linux
 julia:
-  - 1.3
-  - 1.5
+  - 1.4
+  - 1
   - nightly
 env:
   - JULIA_NUM_THREADS=1

--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,16 @@
 name = "Tullio"
 uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 authors = ["Michael Abbott"]
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-# SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 DiffRules = "1"
 Requires = "1"
-# SpecialFunctions = "0.10" # just for this bound
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,12 @@ version = "0.2.10"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+# SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 DiffRules = "1"
 Requires = "1"
-SpecialFunctions = "0.10" # just for this bound
+# SpecialFunctions = "0.10" # just for this bound
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 NamedDims = "356022a1-0364-5f58-8944-0da4b18d706f"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -31,4 +32,4 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "CUDA", "FillArrays", "ForwardDiff", "KernelAbstractions", "LinearAlgebra", "NamedDims", "OffsetArrays", "Printf", "Random", "TensorOperations", "Tracker", "Zygote"]
+test = ["Test", "CUDA", "FillArrays", "ForwardDiff", "KernelAbstractions", "LinearAlgebra", "LoopVectorization", "NamedDims", "OffsetArrays", "Printf", "Random", "TensorOperations", "Tracker", "Zygote"]

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -70,7 +70,8 @@ using Requires
     @inline allzero(seen::Int) = iszero(seen)
     @inline allzero(seen::SVec{N,Int}) where {N} = iszero((!iszero(seen)).u)
 
-    @inline Tullio.anyone(cond::Mask) = cond != zero(cond)
+    # @inline Tullio.anyone(cond::Mask) = cond != zero(cond)
+    @inline Tullio.anyone(cond::Mask) = cond.u != zero(cond).u # for v0.9
 
     @require ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210" begin
         # Dual numbers + svec, should live in PaddedMatricesForwardDiff?

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -53,12 +53,11 @@ using Requires
 
 @init @require LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890" begin
     using .LoopVectorization
-    SVec = if isdefined(LoopVectorization, :SVec) # version 0.8, for Julia ⩽1.5
+    if isdefined(LoopVectorization, :SVec) # version 0.8, for Julia ⩽1.5
         using .LoopVectorization.VectorizationBase: SVec, Mask, prevpow2
-        Svec
     else # version 0.9, supports Julia 1.6
         using .LoopVectorization.VectorizationBase: Vec, Mask, prevpow2
-        Vec
+        SVec{N,T} = Vec{N,T}
     end
 
     # Functions needed for safe vectorised max gradient

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1070,10 +1070,9 @@ function make_many_actors(act!, args, ex1, outer::Vector, ex3, inner::Vector, ex
     safe = if act! == ACT!
         isempty(store.unsafeleft)
     else # working on ∇act!
-        isempty(store.unsaferight)
+        isempty(store.unsaferight) &&
+            store.redfun == :+  && store.grad != :Dual # Disable @avx except for simplest grad, #53
     end
-
-    safe = safe && store.redfun == :+ # Disable @avx for min/max reductions, #53
 
     if safe && store.avx != false && isdefined(store.mod, :LoopVectorization)
         unroll = store.avx == true ? 0 : store.avx # unroll=0 is the default setting

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1071,7 +1071,8 @@ function make_many_actors(act!, args, ex1, outer::Vector, ex3, inner::Vector, ex
         isempty(store.unsafeleft)
     else # working on ∇act!
         isempty(store.unsaferight) &&
-            store.redfun == :+  # Disable @avx for min/max grad, #53
+            store.redfun == :+ && # Disable @avx for min/max grad, #53
+            store.grad != :Dual   # and for use with ForwardDiff
     end
 
     if safe && store.avx != false && isdefined(store.mod, :LoopVectorization)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1071,7 +1071,7 @@ function make_many_actors(act!, args, ex1, outer::Vector, ex3, inner::Vector, ex
         isempty(store.unsafeleft)
     else # working on ∇act!
         isempty(store.unsaferight) &&
-            store.redfun == :+  && store.grad != :Dual # Disable @avx except for simplest grad, #53
+            store.redfun == :+  # Disable @avx for min/max grad, #53
     end
 
     if safe && store.avx != false && isdefined(store.mod, :LoopVectorization)

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -1073,6 +1073,8 @@ function make_many_actors(act!, args, ex1, outer::Vector, ex3, inner::Vector, ex
         isempty(store.unsaferight)
     end
 
+    safe = safe && store.redfun == :+ # Disable @avx for min/max reductions, #53
+
     if safe && store.avx != false && isdefined(store.mod, :LoopVectorization)
         unroll = store.avx == true ? 0 : store.avx # unroll=0 is the default setting
         info1 = store.verbose>0 ? :(@info "running LoopVectorization actor $($note)" maxlog=3 _id=$(hash(store))) : nothing

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -266,8 +266,8 @@ if Tullio._GRAD[] != :Dual
         dv = ForwardDiff.gradient(v -> sum(f7(m2,v)), v2)
         @test dv ≈ _gradient(sum∘f7, m2, v2)[2]
 
-        f8(x,y) = @tullio (max) z[i,l] := log(x[i,j,k,l]) / y[j]^1/3
-        f9(x,y) = @tullio (min) z[i,j] := log(x[i,j,k,l]) / y[j]^1/3
+        f8(x,y) = @tullio (max) z[i,l] := log(x[i,j,k,l]) / y[j]^1/3 avx=false # gives wrong answers
+        f9(x,y) = @tullio (min) z[i,j] := log(x[i,j,k,l]) / y[j]^1/3 avx=false
 
         dm = ForwardDiff.gradient(m -> sum(f8(m,v2)), m4)
         @test dm ≈_gradient(sum∘f8, m4, v2)[1]

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -259,24 +259,24 @@ if Tullio._GRAD[] != :Dual
         dv = ForwardDiff.gradient(v -> sum(f6(m2,v)), v2)
         @test dv ≈ _gradient(sum∘f6, m2, v2)[2]
 
-        f7(x,y) = @tullio (max) z[i] := x[i,j]^2 / sqrt(y[i]) + exp(y[j])
+        f7(x,y) = @tullio (max) z[i] := x[i,j]^2 / sqrt(y[i]) + exp(y[j]) avx=false
 
         dm = ForwardDiff.gradient(m -> sum(f7(m,v2)), m2)
-        @test dm ≈_gradient(sum∘f7, m2, v2)[1]
+        @test dm ≈_gradient(sum∘f7, m2, v2)[1]  # gives wrong answers with avx, 1.4 in tests
         dv = ForwardDiff.gradient(v -> sum(f7(m2,v)), v2)
         @test dv ≈ _gradient(sum∘f7, m2, v2)[2]
 
-        f8(x,y) = @tullio (max) z[i,l] := log(x[i,j,k,l]) / y[j]^1/3 avx=false # gives wrong answers
+        f8(x,y) = @tullio (max) z[i,l] := log(x[i,j,k,l]) / y[j]^1/3 avx=false
         f9(x,y) = @tullio (min) z[i,j] := log(x[i,j,k,l]) / y[j]^1/3 avx=false
 
         dm = ForwardDiff.gradient(m -> sum(f8(m,v2)), m4)
-        @test dm ≈_gradient(sum∘f8, m4, v2)[1]
+        @test dm ≈ _gradient(sum∘f8, m4, v2)[1]  # gives wrong answers with avx, 1.5 in tests
         dv = ForwardDiff.gradient(v -> sum(f8(m4,v)), v2)
         @test dv ≈ _gradient(sum∘f8, m4, v2)[2]
         dm = ForwardDiff.gradient(m -> sum(f9(m,v2)), m4)
-        @test dm ≈_gradient(sum∘f9, m4, v2)[1]
+        @test dm ≈_gradient(sum∘f9, m4, v2)[1]  # gives wrong answers with avx, repl
         dv = ForwardDiff.gradient(v -> sum(f9(m4,v)), v2)
-        @test dv ≈ _gradient(sum∘f9, m4, v2)[2]
+        @test dv ≈ _gradient(sum∘f9, m4, v2)[2]  # gives wrong answers with avx
 
     end
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -505,7 +505,7 @@ end
 
     # promotion of init & += cases:
     B = rand(10)
-    @test sum(B.^2)+2 ≈ @tullio s2 := B[i]^2 init=2 threads=false
+    @test sum(B.^2)+2 ≈ @tullio s2 := B[i]^2 init=2 threads=false avx=false # InexactError: Int64 on LV 0.8
     s3 = 3
     @test sum(B.^2)+3 ≈ @tullio s3 += B[i]^2
     s4 = 4im

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -566,18 +566,18 @@ end
     # reading
     N = NamedDimsArray(rand(Int8,3,10), (:r, :c))
 
-    @tullio A[i,j] := N[i, j] + 100 * (1:10)[j]
+    @tullio A[i,j] := N[i, j] + 100 * (1:10)[j] avx=false # conversion to pointer not defined for NamedDimsArray
     @test A == N .+ 100 .* (1:10)'
 
-    @tullio B[i] := N[r=i, c=1]
+    @tullio B[i] := N[r=i, c=1] avx=false
     @test B == N[:,1]
 
-    @tullio C[j,i] := N[c=j, r=i] + 100 * (1:10)[j]
+    @tullio C[j,i] := N[c=j, r=i] + 100 * (1:10)[j] avx=false
     @test A == C'
     @test dimnames(C) == (:_, :_) # similar(parent(A)) avoids a bug
 
     # writing
-    @tullio M[row=i, col=j, i=1] := (1:3)[i] // (1:7)[j]
+    @tullio M[row=i, col=j, i=1] := (1:3)[i] // (1:7)[j] avx=false
     @test dimnames(M) == (:row, :col, :i)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,7 +200,7 @@ _gradient(x...) = Yota.grad(x...)[2]
 =#
 
 #===== LoopVectorization =====#
-=#
+
 t8 = time()
 using LoopVectorization
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,8 @@ end
 
 #===== Zygote =====#
 
+if VERSION < v"1.6-" # Zygote isn't working on 1.6
+
 t5 = time()
 using Zygote
 
@@ -109,7 +111,6 @@ _gradient(x...) = Zygote.gradient(x...)
 @testset "gradients: Zygote + ForwardDiff" begin include("gradients.jl") end
 
 @tullio grad=Base
-if VERSION >= v"1.4" # mysterious failures on 1.3
 @testset "complex gradients with Zygote" begin
 
     x0 = [1,2,3] .+ [5im, 0, -11im]
@@ -161,9 +162,10 @@ if VERSION >= v"1.4" # mysterious failures on 1.3
 
     end
 end
-end # VERSION
 
 @info @sprintf("Zygote tests took %.1f seconds", time()-t5)
+
+end # VERSION
 
 #===== ReverseDiff =====#
 #=
@@ -244,6 +246,8 @@ _gradient(x...) = Tracker.gradient(x...)
 @tullio grad=Base
 @testset "gradients: Tracker + TensorOperations" begin include("gradients.jl") end
 
+if VERSION < v"1.6-" # Zygote isn't working on 1.6
+
 using Zygote
 GRAD = :Zygote
 _gradient(x...) = Zygote.gradient(x...)
@@ -272,6 +276,8 @@ _gradient(x...) = Zygote.gradient(x...)
 
     end
 end
+
+end # VERSION
 
 @testset "parsing + TensorOperations" begin include("parsing.jl") end # testing correct fallback
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,6 +230,8 @@ _gradient(x...) = Tracker.gradient(x...)
 
 @info @sprintf("LoopVectorization tests took %.1f seconds", time()-t8)
 
+@tullio avx=false
+
 #===== TensorOperations =====#
 
 t9 = time()


### PR DESCRIPTION
Closes #51 , closes #38 .

Lines with `avx=false` in test/parsing.jl produce errors (LoopVectorization v0.9.1, Tullio 0.2.10), although many more don't work with LV (either caught by try/catch during expansion, or else never called by dispatch). 

`Tullio.onlyone` is part of the vectorised gradient for reductions over `max`, ~~not sure it's sufficiently tested.~~ now tested, but gradients still seem problematic. But I don't think this is a regression. 

https://github.com/mcabbott/Tullio.jl/commit/7896059b78a737a467af881d2afb3e36986af7a7 and https://github.com/mcabbott/Tullio.jl/commit/90f32e39d7c2f59c199815d0759df820a8a95123 (on master before this branch) are ~~what's needed for LoopVectorization v0.9.~~ first attempts.