### PR TITLE
Mark all shifted indices unsafe in gradients

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -310,6 +310,7 @@ function parse_input(expr, store)
     unique!(store.leftind)
     store.sharedind = unique!(setdiff(store.sharedind, store.notfree))
     store.rightind = unique!(setdiff(store.rightind, store.notfree))
+    union!(store.unsaferight, store.shiftedind)
     any(==(:_), vcat(store.leftind, store.rightind)) && throw("can't use _ as an index name")
 
     unique!(store.outpre) # kill mutiple assertions, and evaluate any f(A) only once

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -2,7 +2,7 @@
 using Tullio, Test
 using CUDA, KernelAbstractions
 CUDA.allowscalar(false)
-using Tracker
+using Tracker, ForwardDiff
 @tullio grad=Base
 
 # matmul
@@ -17,7 +17,6 @@ A = rand(3,40); B = rand(40,500);
 @test ΔA ≈ ones(3,500) * B'
 @test cu(ΔA) ≈ Tracker.gradient((A,B) -> sum(mul(A, B)), cu(A), cu(B))[1]
 
-#=
 # shifts
 @tullio D[i,j] := A[i,j+k]  k in 0:10
 @test axes(D) == (1:3, 1:30)
@@ -25,6 +24,7 @@ A = rand(3,40); B = rand(40,500);
 @test cD isa CuArray
 @test cD ≈ cu(D)
 
+#=
 # ranges
 @tullio E[i,j] := A[i,j+k-1] + (-1:0.5:1)[k]
 @test axes(E) == (1:3, 1:36)


### PR DESCRIPTION
This should fix #85

Here the crucial part is `tuple(), tuple(𝒶𝓍i, 𝒶𝓍j)`: the first set of indices are safe to multi-thread, the second are not, so this will be done sequentially:
```julia
julia> using Tullio

julia> reg(x) = @tullio res = sqrt(abs2(x[i, j] - x[i+1, j]) +abs2(x[i, j] - x[i, j+1])) verbose=2
...
┌ Info: <<<<< Gradient maker function
│   verbosetidy(ex_make) =
│    quote
│        local function ∇ℳ𝒶𝓀ℯ(𝛥ℛ::𝒯, ℛ, x) where 𝒯
│                local 𝛥x = fill!(similar(x, Base.promote_type(eltype(x), 𝒯)), 0)
│                local 𝒶𝓍j = intersect((axes)(x, 2), (axes)(x, 2), (axes)(x, 2), (axes)(x, 2) .- 1)
│                local 𝒶𝓍i = intersect((axes)(x, 1), (axes)(x, 1) .- 1, (axes)(x, 1), (axes)(x, 1))
│                (Tullio.∇threader)(∇𝒜𝒸𝓉!, (Tullio.storage_type)(𝛥x, x), tuple(𝛥x, (Tullio.OneBox)(𝛥ℛ), ℛ, x), tuple(), tuple(𝒶𝓍i, 𝒶𝓍j), 8457)
│                return (𝛥x,)
│            end
└    end
...
┌ Warning: using KernelAbstractions with no outer indices, this will be slow
└ @ Tullio ~/.julia/dev/Tullio/src/macro.jl:1139
```
This also affects convolutions like `@tullio a[i] := b[i-k] * c[k]`, which won't multi-thread at all. 

Should add a test, perhaps to GPU set. 