### PR TITLE
Remove automatic use of TensorOperations

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ M1, M2, M3 = randn(30,30), randn(30,30), randn(30,30);
 @btime @tullio M4[i,l] := $M1[i,j] * $M2[j,k] * $M3[k,l]; # 30.401 μs
 ```
 
+Or slightly less obviously:
+
+```julia
+M, Σ = randn(100,100), randn(100,100);
+@tullio R4[i, j] := (M[μ, i] - M[μ,j])' * Σ[μ,ν] * (M[ν, i] - M[ν, j]);
+begin
+  S = M' * Σ * M  # two N^3 operations, instead of one N^4
+  @tullio R3[i,j] := S[i,i] + S[j,j] - S[i,j] - S[j,i]
+end;
+R3 ≈ R4
+```
+
 Another thing Tullio can be very fast at is broadcast reductions, where it can avoid large allocations. Here LoopVectorization is speeding up `log`, and Tullio is handling tiled memory access and multi-threading:
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ But it also co-operates with various other packages, provided they are loaded be
 
 * It uses [`KernelAbstractions.@kernel`](https://github.com/JuliaGPU/KernelAbstractions.jl) to make a GPU version. (Disable with `cuda=false`.) This is somewhat experimental, and may not be fast.
 
-* It uses [`TensorOperations.@tensor`](https://github.com/Jutho/TensorOperations.jl) on expressions which this understands. (Disable with `tensor=false`.) These must be Einstein-convention contractions of one term; none of the examples above qualify.
-
 The macro also tries to provide a gradient for use with [Tracker](https://github.com/FluxML/Tracker.jl) or [Zygote](https://github.com/FluxML/Zygote.jl). <!-- or [ReverseDiff](https://github.com/JuliaDiff/ReverseDiff.jl). -->
 (Disable with `grad=false`, or `nograd=A`.) This is done in one of two ways:
 
@@ -325,6 +323,10 @@ Extras:
 * Similarly, `A[pad(i,3)]` extends the range of `i`, inserting zeros outside of `A`. Instead of zero, `pad=NaN` uses this value as padding. The implementation of this (and `mod`, `clamp`) is not very fast at present.
 * On the left, when making a new array, an underscore like `A[i+_] :=` inserts whatever shift is needed to make `A` one-based.
 * `Tullio.@printgrad (x+y)*log(x/z)   x y z` prints out how symbolic derivatives will be done.
+
+Macros:
+* `Tullio.@tensor` is a macro which uses TensorOperations to evaluate expressions, but provides gradient definitions. (Previously this was automatic behaviour, when TensorOperations.jl was loaded & the expression was suitable.)
+* `Tullio.@einsum` is a variant with a few changes, to allow the running of Einsum.jl's tests.
 
 </details>
 <details><summary><b>Internals</b></summary>

--- a/test/group-3.jl
+++ b/test/group-3.jl
@@ -181,17 +181,15 @@ using Tracker
 GRAD = :Tracker
 _gradient(x...) = Tracker.gradient(x...)
 
-@tullio grad=Base
-@testset "gradients: Tracker + TensorOperations" begin include("gradients.jl") end
+@testset "gradients: Tracker + TensorOperations" begin include("tensorgrad.jl") end
 
-if VERSION < v"1.6-" # Zygote isn't working on 1.6
+# if VERSION < v"1.6-" # Zygote isn't working on 1.6
 
 using Zygote
 GRAD = :Zygote
 _gradient(x...) = Zygote.gradient(x...)
 
-@tullio grad=Base
-@testset "gradients: Zygote + TensorOperations" begin include("gradients.jl") end
+@testset "gradients: Zygote + TensorOperations" begin include("tensorgrad.jl") end
 
 @testset "complex gradients with TensorOperations" begin
 
@@ -201,23 +199,21 @@ _gradient(x...) = Zygote.gradient(x...)
 
         g1 = _gradient(x -> real(sum(x * x)), x0)[1]
         g1i = _gradient(x -> imag(sum(x * x)), x0)[1]
-        @test g1 ≈ _gradient(x -> real(sum(@tullio y[i,j] := x[i,k] * x[k,j])), x0)[1]
-        @test g1i ≈ _gradient(x -> imag(sum(@tullio y[i,j] := x[i,k] * x[k,j])), x0)[1]
+        @test g1 ≈ _gradient(x -> real(sum(Tullio.@tensor y[i,j] := x[i,k] * x[k,j])), x0)[1]
+        @test g1i ≈ _gradient(x -> imag(sum(Tullio.@tensor y[i,j] := x[i,k] * x[k,j])), x0)[1]
 
     end
-    @testset "non-analytic" begin
+    # @testset "non-analytic" begin
 
-        g2 = _gradient(x -> real(sum(x * x')), x0)[1]
-        g2i = _gradient(x -> imag(sum(x * x')), x0)[1] # zero
-        @test_broken g2 ≈ _gradient(x -> real(sum(@tullio y[i,j] := x[i,k] * conj(x[j,k]))), x0)[1]
-        @test_broken g2i ≈ _gradient(x -> imag(sum(@tullio y[i,j] := x[i,k] * conj(x[j,k]))), x0)[1]
+    #     g2 = _gradient(x -> real(sum(x * x')), x0)[1]
+    #     g2i = _gradient(x -> imag(sum(x * x')), x0)[1] # zero
+    #     @test_broken g2 ≈ _gradient(x -> real(sum(Tullio.@tensor y[i,j] := x[i,k] * conj(x[j,k]))), x0)[1]
+    #     @test_broken g2i ≈ _gradient(x -> imag(sum(Tullio.@tensor y[i,j] := x[i,k] * conj(x[j,k]))), x0)[1]
 
-    end
+    # end
 end
 
-end # VERSION
-
-@testset "parsing + TensorOperations" begin include("parsing.jl") end # testing correct fallback
+# end # VERSION
 
 @info @sprintf("TensorOperations tests took %.1f seconds", time()-t9)
 

--- a/test/group-3.jl
+++ b/test/group-3.jl
@@ -183,7 +183,7 @@ _gradient(x...) = Tracker.gradient(x...)
 
 @testset "gradients: Tracker + TensorOperations" begin include("tensorgrad.jl") end
 
-# if VERSION < v"1.6-" # Zygote isn't working on 1.6
+if VERSION < v"1.6-" # Zygote isn't working on 1.6
 
 using Zygote
 GRAD = :Zygote
@@ -203,17 +203,19 @@ _gradient(x...) = Zygote.gradient(x...)
         @test g1i ≈ _gradient(x -> imag(sum(Tullio.@tensor y[i,j] := x[i,k] * x[k,j])), x0)[1]
 
     end
-    # @testset "non-analytic" begin
+    #=  # conj isn't handled by gradient code for @tensor here
+    @testset "non-analytic" begin
 
-    #     g2 = _gradient(x -> real(sum(x * x')), x0)[1]
-    #     g2i = _gradient(x -> imag(sum(x * x')), x0)[1] # zero
-    #     @test_broken g2 ≈ _gradient(x -> real(sum(Tullio.@tensor y[i,j] := x[i,k] * conj(x[j,k]))), x0)[1]
-    #     @test_broken g2i ≈ _gradient(x -> imag(sum(Tullio.@tensor y[i,j] := x[i,k] * conj(x[j,k]))), x0)[1]
+        g2 = _gradient(x -> real(sum(x * x')), x0)[1]
+        g2i = _gradient(x -> imag(sum(x * x')), x0)[1] # zero
+        @test_broken g2 ≈ _gradient(x -> real(sum(Tullio.@tensor y[i,j] := x[i,k] * conj(x[j,k]))), x0)[1]
+        @test_broken g2i ≈ _gradient(x -> imag(sum(Tullio.@tensor y[i,j] := x[i,k] * conj(x[j,k]))), x0)[1]
 
-    # end
+    end
+    =#
 end
 
-# end # VERSION
+end # VERSION
 
 @info @sprintf("TensorOperations tests took %.1f seconds", time()-t9)
 

--- a/test/group-3.jl
+++ b/test/group-3.jl
@@ -183,8 +183,6 @@ _gradient(x...) = Tracker.gradient(x...)
 
 @testset "gradients: Tracker + TensorOperations" begin include("tensorgrad.jl") end
 
-if VERSION < v"1.6-" # Zygote isn't working on 1.6
-
 using Zygote
 GRAD = :Zygote
 _gradient(x...) = Zygote.gradient(x...)
@@ -214,8 +212,6 @@ _gradient(x...) = Zygote.gradient(x...)
     end
     =#
 end
-
-end # VERSION
 
 @info @sprintf("TensorOperations tests took %.1f seconds", time()-t9)
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -596,20 +596,20 @@ end
     # when using KernelAbstractions, something leaks from the 1st leading 2nd to error
     block = 64
     @tullio A[i] := (1:10)[i]^2  threads=block # Symbol
-    @test_throws LoadError @macroexpand1 @tullio A[i] := (1:10)[i]^2  threads=:maybe
+    @test_throws LoadError @eval @tullio A[i] := (1:10)[i]^2  threads=:maybe
 
     # keyword verbose accepts values [true, false, 2, 3]
     @tullio A[i] := (1:10)[i]^2  verbose=1 avx=false # @error: rejected by LoopVectorization's check_args
     @tullio A[i] := (1:10)[i]^2  verbose=false
-    @test_throws LoadError @macroexpand1 @tullio A[i] := (1:10)[i]^2  verbose=4
+    @test_throws LoadError @eval @tullio A[i] := (1:10)[i]^2  verbose=4
 
     # keyword grad accepts values [false, Base, Dual]
     @tullio A[i] := (1:10)[i]^2  grad=false
     @tullio A[i] := (1:10)[i]^2  grad=Base
-    @test_throws LoadError @macroexpand1 @tullio A[i] := (1:10)[i]^2  grad=true
+    @test_throws LoadError @eval @tullio A[i] := (1:10)[i]^2  grad=true
 
     # recognised keywords are [:threads, :verbose, :avx, :cuda, :grad]
-    @test_throws LoadError @macroexpand1 @tullio A[i] := (1:10)[i]^2  key=nothing
+    @test_throws LoadError @eval @tullio A[i] := (1:10)[i]^2  key=nothing
 
 end
 

--- a/test/tensorgrad.jl
+++ b/test/tensorgrad.jl
@@ -1,0 +1,82 @@
+
+using Tullio, Test, ForwardDiff
+# using Tracker; _gradient(x...) = Tracker.gradient(x...); GRAD = :Tracker
+
+function gradtest(f, dims)
+    x = randn(dims...)
+    grad = ForwardDiff.gradient(x -> sum(sin, f(x)), x)
+    grad ≈ _gradient(x -> sum(sin, f(x)), x)[1]
+end
+
+@testset "from TensorTrace" begin
+    # These can all be handled using TensorOperations
+
+    triv1(x) = Tullio.@tensor A[i,j] := 2 * x[i,j]
+    @test gradtest(triv1, (2,3))
+
+    r32 = randn(3,2);
+    r312 = randn(3,1,2);
+
+    ## trace!
+    tr1(x) = Tullio.@tensor T[k] := 22 * x[i,i,k]
+    @test gradtest(tr1, (3,3,4))
+
+    tr2(x) = Tullio.@tensor T[k] := 22 * x[i,i,k,j,j]
+    @test gradtest(tr2, (3,3,4,7,7))
+
+    ## contract! A
+    con1(x) = Tullio.@tensor C[i,j] := 5 * x[i,k] * r32[k,j]
+    @test gradtest(con1, (2,3))
+
+    r22 = rand(2,2);
+
+    con3(x) = Tullio.@tensor C[i,j,m,n] := x[i,j,k] * r312[k,m,n]
+    @test gradtest(con3, (1,2,3))
+
+    con4(x) = Tullio.@tensor C[i,m] := x[i,kk,k] * r312[k,m,kk]
+    @test gradtest(con4, (1,2,3))
+
+    con5(x) = Tullio.@tensor C[j,i,n,m] := 44 * x[i,j,k] * r312[k,m,n]
+    @test gradtest(con5, (1,2,3))
+
+    r392 = randn(3,9,2);
+    con6(x) = Tullio.@tensor C[n,i,m,j] := x[i,j,k] * r392[k,m,n]
+    @test gradtest(con6, (9,2,3))
+
+    con7(x) = Tullio.@tensor C[m,n,j,i] := 44 * x[i,j,k] * r392[k,m,n]
+    @test gradtest(con7, (9,2,3))
+
+    ## contract! B
+    con8b(x) = Tullio.@tensor K[i,j] := 5 * r32[i,k] * x[k,j]
+    @test gradtest(con8b, (2,3))
+
+    con9b(x) = Tullio.@tensor K[i,j,m,n] := r312[i,j,k] * x[m,k,n]
+    @test gradtest(con9b, (1,2,3))
+
+    con10b(x) = Tullio.@tensor K[n,j,m,i] := r392[i,j,k] * x[m,k,n]
+    @test gradtest(con10b, (9,2,3))
+
+    r3399 = randn(3,3,9,9);
+
+    con13(x) = Tullio.@tensor K[i,j] := r3399[s,s,j,k] * x[t,t,k,i]
+    @test gradtest(con13, (3,3,9,9))
+
+    r33 = rand(3,3);
+    con14(x) = Tullio.@tensor K[i,j] := r3399[a,b,j,k] * x[b,c,k,i] * r33[a,c]
+    @test gradtest(con14, (3,3,9,9))
+
+    ## scalar -- one with :=, one without
+    sc1(x) = Tullio.@tensor s = r22[b,β] * x[a,b,c] * r312[c,a,β]
+    @test gradtest(sc1, (1,2,3))
+
+    sc2(x) = Tullio.@tensor s := x[γ,c] * r3399[c,γ,i,i]
+    @test gradtest(sc2, (3,3))
+
+end
+
+@testset "errors" begin
+    @test_throws LoadError @eval Tullio.@tensor C[k] := A[i,i,k] + B[k]  # two terms
+    @test_throws LoadError @eval Tullio.@tensor B[k] := conj(A[k])  # functions
+    @test_throws LoadError @eval Tullio.@tensor C[k] := A[i, i+k]  # not a contraction
+end
+


### PR DESCRIPTION
This makes an explicit `Tullio.@tensor` macro, rather than automatically dispatching some `@tullio` calls to TensorOperations. 

Now https://github.com/ho-oto/TensorRules.jl  is another option for this, and the unregistered https://github.com/mcabbott/TensorGrad.jl .