### PR TITLE
Fix linear indexing of offset vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tullio"
 uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 authors = ["Michael Abbott"]
-version = "0.2.13"
+version = "0.2.14"
 
 [deps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"

--- a/src/shifts.jl
+++ b/src/shifts.jl
@@ -7,6 +7,7 @@ linearindex(A::Tuple) = eachindex(A)
 linearindex(A::AbstractArray) = linearindex(IndexStyle(A), A)
 linearindex(::LinearIndices, A::AbstractArray) = eachindex(A)
 linearindex(::IndexStyle, A::AbstractArray) = Base.OneTo(length(A))
+linearindex(::IndexStyle, v::AbstractVector) = UnitRange(eachindex(v))
 
 #========== adjusting index ranges, runtime ==========#
 

--- a/src/shifts.jl
+++ b/src/shifts.jl
@@ -3,11 +3,8 @@
 
 # Not so related to shifts, but has to live somewhere! (Runtime.)
 
-linearindex(A::Tuple) = eachindex(A)
-linearindex(A::AbstractArray) = linearindex(IndexStyle(A), A)
-linearindex(::LinearIndices, A::AbstractArray) = eachindex(A)
-linearindex(::IndexStyle, A::AbstractArray) = Base.OneTo(length(A))
-linearindex(::IndexStyle, v::AbstractVector) = UnitRange(eachindex(v))
+linearindex(A) = Base.OneTo(length(A))  # Tuple, AbstractArray
+linearindex(v::AbstractVector) = Base.axes1(v)
 
 #========== adjusting index ranges, runtime ==========#
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -369,6 +369,9 @@ using OffsetArrays
     @tullio L[i] := I[i] + 1 # I is an offset matrix
     @test L == vec(I) .+ 1
 
+    V = OffsetArray([1,10,100,1000],2) # offset vector
+    @test axes(@tullio _[i] := log10(V[i])) == (3:6,)
+
     # indexing by an array
     inds = [-1,0,0,0,1]
     @tullio K[i,j] := A[inds[i]+j]


### PR DESCRIPTION
Fixes a bug introduced in #87: 
```julia
julia> using Tullio, OffsetArrays

julia> V = OffsetArray(fill(100,5),2)
5-element OffsetArray(::Vector{Int64}, 3:7) with eltype Int64 with indices 3:7:
 100
 100
 100
 100
 100

julia> @tullio W[i] := V[i] + i 
5-element Vector{Int64}:
 4542347537
 4542347058
        103
        104
        105

(jl_b1fFXN) pkg> st Tullio
      Status `/private/var/folders/yq/4p2zwd614y59gszh7y9ypyhh0000gn/T/jl_b1fFXN/Project.toml`
  [bc48ee85] Tullio v0.2.13
```
After:
```julia
julia> @tullio W[i] := V[i] + i
5-element OffsetArray(::Vector{Int64}, 3:7) with eltype Int64 with indices 3:7:
 103
 104
 105
 106
 107
```