### PR TITLE
Disallow `div` in indexing

### DIFF
--- a/src/shifts.jl
+++ b/src/shifts.jl
@@ -68,28 +68,6 @@ issubset(addranges(1:10, 1:3) .- 1, 1:10)
 issubset(addranges(1:10, 1:3) .- 3, 1:10)
 =#
 
-# # This is to get range of j in A[j÷2], from axes(A,1):
-
-function mulrange(r::AbstractUnitRange, f::Integer)
-    first(r)*f : last(r)*f
-end
-
-function dotdiv(r::AbstractUnitRange, f::Integer)
-    first(r)÷f : last(r)÷f
-end
-
-#=
-mulrange(1:10, 2) .÷ 2 |> unique
-mulrange(0:10, 2) .÷ 2 |> unique
-mulrange(1:11, 2) .÷ 2 |> unique
-
-mulrange(1:10, 3) .÷ 3 |> unique
-mulrange(-10:-1, 3) .÷ 3 |> unique
-mulrange(-11:-1, 3) .÷ 3 |> unique
-mulrange(-11:-2, 3) .÷ 3 |> unique
-mulrange(-12:-3, 3) .÷ 3 |> unique
-=#
-
 # This is for A[I[j]] (where this range must be a subset of axes(A,1))
 # and for A[I[j]+k] (where it enters into the calculation of k's range).
 
@@ -184,10 +162,8 @@ function range_expr_walk(r, ex::Expr, con=[])
         elseif op == :*
             is_const(a) && return range_expr_walk(:($divrange($r, $a)), b)
             is_const(b) && return range_expr_walk(:($divrange($r, $b)), a)
-        elseif op == :÷
-            is_const(b) && return range_expr_walk(:($mulrange($r, $b)), a)
-        elseif op == :/
-            throw("not sure what to do with $ex, perhaps you wanted ÷")
+        elseif op in (:÷, :/)
+            throw("division using ÷ or / in indexing is not supported")
         end
     elseif length(ex.args) > 3
         op, a, b, c = ex.args[1:4]
@@ -259,8 +235,6 @@ range_unwrap(ex::Expr) = begin
         elseif op == :-
             is_const(a) && return :($a .- $(range_unwrap(b)))
             is_const(b) && return :($(range_unwrap(a)) .- $b)
-        elseif op == :÷
-            is_const(b) && return :($dotdiv($(range_unwrap(a)), $b))
         end
     end
     throw("don't know how to handle $ex, sorry")

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -358,7 +358,7 @@ if Tullio._GRAD[] != :Dual
 
         @printline
 
-        mx3(x) = @tullio (max) r[i] := x[i,j]^3 |> cbrt
+        mx3(x) = @tullio (max) r[i] := x[i,j]^3 |> cbrt  avx=false # sometimes gets stuck here?
         mx3(mat) # hmmm what is this?
         _gradient(sum∘mx3, mat)[1] # zero
 

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -226,10 +226,12 @@ end
     @printline
 
     ## scalar -- one with :=, one without
-    sc1(x) = @tullio s = r22[b,β] * x[a,b,c] * r312[c,a,β]  avx=false
+    sc1(x) = @tullio s = r22[b,β] * x[a,b,c] * r312[c,a,β]  avx=false verbose=true
     @test gradtest(sc1, (1,2,3)) # UndefVarError: ####op#798_0 not defined
 
-    sc2(x) = @tullio s := x[γ,c] * r3399[c,γ,i,i]  avx=false
+    @printline
+
+    sc2(x) = @tullio s := x[γ,c] * r3399[c,γ,i,i]  avx=false verbose=true
     @test gradtest(sc2, (3,3))
 
 end
@@ -353,6 +355,8 @@ if Tullio._GRAD[] != :Dual
 
         # relu(x) = max(x, zero(x))
         # lay2(x) = @tullio y[i,k] := mat[i,j] * x[j,k] |> relu
+
+        @printline
 
         mx3(x) = @tullio (max) r[i] := x[i,j]^3 |> cbrt
         mx3(mat) # hmmm what is this?

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -352,11 +352,6 @@ using OffsetArrays
     @test axes(@tullio J[i,j] := A[-2j+i] + 0 * B[j]) == (9:12, 1:4)
     @test axes(@tullio J[i,j] := A[2i-2j] + 0 * B[j]) == (5:6, 1:4)
 
-    @test axes(@tullio I[i,j] := A[i+j÷2] + 0 * B[j]) == (1:8, 1:4)
-    @test axes(@tullio I[i,j] := A[i+(j-1)÷2] + 0 * B[j]) == (1:9, 1:4)
-    @test axes(@tullio I[i,j] := A[2i+(j-1)÷2] + 0 * B[j] avx=false) == (1:4, 1:4)  # wtf?
-    @test axes(@tullio I[i,j] := A[i+(j-1)÷3] + 0 * B[j]) == (1:9, 1:4)
-
     @test_throws LoadError @eval @tullio I[i,j] := A[i+j] # under-specified
 
     # in-place

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -51,10 +51,6 @@ using Tullio: range_expr_walk, divrange, minusrange, subranges, addranges
             (i -> -1+2i, :(-1+2i)),
             (i -> 1-3i, :(1-3i)),
             (i -> 1-3(i+4), :(1-3(i+4))),
-            # ÷
-            (i -> i÷2, :(i÷2)),
-            (i -> 1+i÷3, :(1+i÷3)),
-            (i -> 1+(i-1)÷3, :(1+(i-1)÷3)),
             # triple...
             (i -> i+1+2, :(i+1+2)),
             (i -> 1+2+i, :(1+2+i)),
@@ -63,7 +59,6 @@ using Tullio: range_expr_walk, divrange, minusrange, subranges, addranges
             (i -> 1+2+3+4(-i), :(1+2+3+4(-i))),
             # evil
             (i -> (2i+1)*3+4, :((2i+1)*3+4)),
-            (i -> 3-(-i)÷2, :(3-(-i)÷2)), # needs divrange_minus
             ]
             rex, i = range_expr_walk(:($r .+ 0), ex)
             @test issubset(sort(f.(eval(rex))), r)
@@ -75,7 +70,6 @@ using Tullio: range_expr_walk, divrange, minusrange, subranges, addranges
         @test extrema(eval(rex)) == (first(r)-1-2, last(r)-1+5)
 
         @test range_expr_walk(:($r .+ 0), :(i+j))[2] == (:i, :j) # weak test!
-        @test range_expr_walk(:($r .+ 0), :(2i+(j-1)÷3))[2] == (:i, :j) # weak test!
 
         # range adjusting functions
         @test minusrange(r) == divrange(r, -1)


### PR DESCRIPTION
Closes #76. Some other attempts to fix the bugs: https://github.com/mcabbott/Tullio.jl/commit/d3e86a07f7ab7347c02767a1380aa1f59f48079c

Xref also #83, not directly touched here.