### PR TITLE
Detect accumulation-like indexing

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -315,6 +315,13 @@ function parse_input(expr, store)
 
     if store.newarray && Z in store.arrays
         throw("can't create a new array $Z when this also appears on the right")
+    elseif Z in store.arrays
+        accumlike = intersect(store.leftind, store.shiftedind)
+        if !isempty(accumlike)
+            @warn "detected accumulation-like behaviour, this might be made an error" accumlike
+            # store.avx = false
+            append!(store.unsafeleft, accumlike)  # this means no threading, but not sure that's enough
+        end
     end
 end
 

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -698,6 +698,15 @@ end
        @tullio x[i] := s[i,j]  avx=false # Unexpected Pass with LV
     end
 
+    # https://github.com/mcabbott/Tullio.jl/issues/115
+    # we must detect that cumsum isn't thread-safe, but should it be illegal?
+    x = rand(Int8, 10) .+ 0
+    y = copy(x)
+    @tullio y[i] = y[i-1] + y[i]
+    @test y == cumsum(x)
+    z = (y=copy(x),)
+    @tullio z.y[i] = z.y[i-1] + z.y[i]  # version with field access
+    @test z.y == cumsum(x)
 end
 
 @printline


### PR DESCRIPTION
Motivated by #115, this detects tries to detect indexing of this pattern:
```julia
x = rand(Int8, 10) .+ 0; y = copy(x)
@tullio y[i] = y[i-1] + y[i]
```
i.e. writing in-place, to an array which appears on the right, with a shifted index. This `i` is very unsafe, worse than merely causing race conditions if multi-threaded, the expected result `y == cumsum(x)` depends on it being done sequentially. It's possibly this should be made an error.