### PR TITLE
Skip code coverage on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           JULIA_NUM_THREADS: ${{ matrix.threads }}
           TULLIO_TEST_GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info
+#       - uses: julia-actions/julia-processcoverage@v1
+#       - uses: codecov/codecov-action@v1
+#         with:
+#           file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: 'false'
         env:
           JULIA_NUM_THREADS: ${{ matrix.threads }}
           TULLIO_TEST_GROUP: ${{ matrix.group }}

--- a/test/gradients.jl
+++ b/test/gradients.jl
@@ -181,7 +181,7 @@ end
     @test gradtest(tr2, (3,3,4,7,7))
 
     ## contract! A
-    con1(x) = @tullio C[i,j] := 5 * x[i,k] * r32[k,j]
+    con1(x) = @tullio C[i,j] := 5 * x[i,k] * r32[k,j]  avx=false  # https://github.com/mcabbott/Tullio.jl/pull/144
     @test gradtest(con1, (2,3))
 
     r22 = rand(2,2);
@@ -208,7 +208,7 @@ end
     con8b(x) = @tullio K[i,j] := 5 * r32[i,k] * x[k,j]  avx=false
     @test gradtest(con8b, (2,3))
 
-    con9b(x) = @tullio K[i,j,m,n] := r312[i,j,k] * x[m,k,n]
+    con9b(x) = @tullio K[i,j,m,n] := r312[i,j,k] * x[m,k,n]  avx=false  # https://github.com/mcabbott/Tullio.jl/pull/144
     @test gradtest(con9b, (1,2,3))
 
     con10b(x) = @tullio K[n,j,m,i] := r392[i,j,k] * x[m,k,n]  avx=false
@@ -216,7 +216,7 @@ end
 
     r3399 = randn(3,3,9,9);
 
-    con13(x) = @tullio K[i,j] := r3399[s,s,j,k] * x[t,t,k,i]
+    con13(x) = @tullio K[i,j] := r3399[s,s,j,k] * x[t,t,k,i]  avx=false  # https://github.com/mcabbott/Tullio.jl/pull/144
     @test gradtest(con13, (3,3,9,9))
 
     r33 = rand(3,3);


### PR DESCRIPTION
This cuts CI time from about 2 hours to about 1/2 hour, by avoiding code coverage. Should still run on Julia master, where this has been made quicker.

Also finds some failures, e.g.:
```julia
julia> using Tracker, Tullio, LoopVectorization, ForwardDiff

julia> @tullio grad=Dual
(verbose = false, fastmath = true, threads = true, grad = :Dual, avx = true, cuda = true)

julia> r32 = randn(3,2);

julia> con1(x) = @tullio C[i,j] := 5 * x[i,k] * r32[k,j]
con1 (generic function with 1 method)

julia> gradient(x -> sum(con1(x)), rand(2,3))
ERROR: MethodError: no method matching vconvert(::Type{VectorizationBase.VecUnroll{1, W, Float64, V} where {W, V<:Union{Bool, Float16, Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8, SIMDTypes.Bit, VectorizationBase.AbstractSIMD{W, Float64}}}}, ::VectorizationBase.VecUnroll{1, 2, Float64, VectorizationBase.Vec{2, Float64}})
Closest candidates are:
  vconvert(::Type{VectorizationBase.VecUnroll{N, W, T, V}}, ::VectorizationBase.VecUnroll{N, W, T} where {W, T}) where {N, W, T, V} at ~/.julia/packages/VectorizationBase/xnzUX/src/llvm_intrin/conversion.jl:137
  vconvert(::Type{VectorizationBase.VecUnroll{N, W, T, V}}, ::VectorizationBase.VecUnroll{N, W, T, V}) where {N, W, T, V} at ~/.julia/packages/VectorizationBase/xnzUX/src/llvm_intrin/conversion.jl:140
  vconvert(::Type{V}, ::VectorizationBase.VecUnroll{N, W, T, V}) where {N, W, T, V<:VectorizationBase.AbstractSIMDVector} at ~/.julia/packages/VectorizationBase/xnzUX/src/llvm_intrin/conversion.jl:107
  ...
Stacktrace:
  [1] convert
    @ ~/.julia/packages/VectorizationBase/xnzUX/src/base_defs.jl:154 [inlined]
  [2] ForwardDiff.Dual{Nothing, VectorizationBase.VecUnroll{1, W, Float64, V} where {W, V<:Union{Bool, Float16, Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8, SIMDTypes.Bit, VectorizationBase.AbstractSIMD{W, Float64}}}, 2}(value::VectorizationBase.VecUnroll{1, 2, Float64, VectorizationBase.Vec{2, Float64}}, partials::ForwardDiff.Partials{2, VectorizationBase.VecUnroll{1, W, Float64, V} where {W, V<:Union{Bool, Float16, Float32, Float64, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8, SIMDTypes.Bit, VectorizationBase.AbstractSIMD{W, Float64}}}})
    @ ForwardDiff ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:19
  [3] Dual
    @ ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:60 [inlined]
  [4] convert
    @ ~/.julia/packages/ForwardDiff/PBzup/src/dual.jl:383 [inlined]
  [5] _promote
    @ ./promotion.jl:336 [inlined]
  [6] promote
    @ ./promotion.jl:359 [inlined]
  [7] mul_fast(::ForwardDiff.Dual{Nothing, VectorizationBase.VecUnroll{1, 2, Float64, VectorizationBase.Vec{2, Float64}}, 2}, ::ForwardDiff.Dual{Nothing, VectorizationBase.VecUnroll{1, 1, Float64, VectorizationBase.VecUnroll{1, 1, Float64, Float64}}, 2})
    @ Base.FastMath ./fastmath.jl:267
  [8] macro expansion
    @ ~/.julia/packages/LoopVectorization/wLMFa/src/reconstruct_loopset.jl:713 [inlined]
  [9] _turbo_!
    @ ~/.julia/packages/LoopVectorization/wLMFa/src/reconstruct_loopset.jl:713 [inlined]
 [10] ∇𝒜𝒸𝓉!
    @ ~/.julia/packages/Tullio/u7Tk0/src/macro.jl:1094 [inlined]
 [11] tile_halves(fun!::var"#∇𝒜𝒸𝓉!#14", ::Type{Matrix{Float64}}, As::NTuple{6, Matrix{Float64}}, Is::Tuple{UnitRange{Int64}}, Js::Tuple{UnitRange{Int64}, UnitRange{Int64}}, keep::Nothing, final::Bool)
    @ Tullio ~/.julia/packages/Tullio/u7Tk0/src/threads.jl:139
```
