### PR TITLE
Allow KernelAbstractions 0.8, etc.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tullio"
 uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 authors = ["Michael Abbott"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -11,12 +11,12 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 CUDA = "3.6"
-CUDAKernels = "0.3.3"
+CUDAKernels = "0.3.3, 0.4"
 ChainRulesCore = "1"
 DiffRules = "1"
-FillArrays = "0.11, 0.12"
+FillArrays = "0.11, 0.12, 0.13"
 ForwardDiff = "0.10"
-KernelAbstractions = "0.7.2"
+KernelAbstractions = "0.7.2, 0.8"
 LoopVectorization = "0.12.101"
 NamedDims = "0.2"
 OffsetArrays = "1"


### PR DESCRIPTION
CompatHelper didn't see this somehow?