### PR TITLE
Add note about reduction scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ dbl!(M, S)
 @test all(M[r,c] == 2*S[1,c] for r ∈ 1:3, c ∈ 1:7)
 ```
 
+**Note:**
+
+Unlike most other einstein summation convections, Tullio will wrap the entire right hand side in a reduction, and will not attempt to do term-wise contractions.
+Hence, writing expressions like
+```juia
+@tullio D[i, j] := A[i, k] * B[k, j] + c[i]
+```
+is *not* the same as $D_{ij} = \sum_{k}(A_{ik} B_{kj}) + c_i$ but instead $D_{ij} = \sum_{k}(A_{ik} B_{kj} + c_i)$. This is a natural consequence of Tullio attempting to support general reductions over general code.  
+
+____________
+
 More complicated examples:
 
 ```julia


### PR DESCRIPTION
Ref https://github.com/mcabbott/Tullio.jl/issues/133 and https://discourse.julialang.org/t/tullio-broadcasting-issue/107321/4. I was pretty surprised by this as well, but it makes sense in retrospect because Tullio is really less of an "Einstein notation DSL" and more of a "general reduction notation DSL".

Open to suggestions for how to make it more clear, or where is best to put this in the README. 