### PR TITLE
Allow Zygote v0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tullio"
 uuid = "bc48ee85-29a4-5162-ae0b-a64e1601d4bc"
 authors = ["Michael Abbott"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -29,13 +29,13 @@ FillArrays = "0.11, 0.12, 0.13, 1"
 ForwardDiff = "0.10, 1.0"
 KernelAbstractions = "0.9"
 LoopVectorization = "0.12.101"
-NamedDims = "0.2"
+NamedDims = "0.2, 1"
 OffsetArrays = "1"
 Requires = "1"
 TensorOperations = "4, 5"
 Tracker = "0.2"
 VectorizationBase = "0.21.23"
-Zygote = "0.6.33"
+Zygote = "0.6.33, 0.7"
 julia = "1.10"
 
 [extras]

--- a/ext/TullioChainRulesCoreExt.jl
+++ b/ext/TullioChainRulesCoreExt.jl
@@ -6,7 +6,7 @@ function ChainRulesCore.rrule(ev::Tullio.Eval, args...)
     Z = ev.fwd(args...)
     Z, function tullio_back(Δ)
         isnothing(ev.rev) && error("no gradient definition here!")
-        dxs = map(ev.rev(Δ, Z, args...)) do dx
+        dxs = map(ev.rev(unthunk(Δ), Z, args...)) do dx
             dx === nothing ? ChainRulesCore.ZeroTangent() : dx
         end
         tuple(ChainRulesCore.ZeroTangent(), dxs...)


### PR DESCRIPTION
Aims to solve errors like this, because the new Zygote allows thunks:
```julia
ERROR: MethodError: no method matching (::var"#170#∇ℳ𝒶𝓀ℯ#46"{…})(::ChainRulesCore.Thunk{…}, ::Array{…}, ::Array{…}, ::Array{…})
The function `#170#∇ℳ𝒶𝓀ℯ` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  (::var"#170#∇ℳ𝒶𝓀ℯ#46")(::AbstractArray{𝒯}, ::Any, ::Any, ::Any) where 𝒯
   @ Main ~/.julia/packages/Tullio/vChiX/src/macro.jl:1295

Stacktrace:
  [1] (::TullioChainRulesCoreExt.var"#tullio_back#2"{…})(Δ::ChainRulesCore.Thunk{…})
    @ TullioChainRulesCoreExt ~/.julia/packages/Tullio/vChiX/ext/TullioChainRulesCoreExt.jl:9
  [2] (::Zygote.ZBack{TullioChainRulesCoreExt.var"#tullio_back#2"{…}})(dy::ChainRulesCore.Thunk{Zygote.var"#167#168"{…}})
    @ Zygote ~/.julia/packages/Zygote/ZtfX6/src/compiler/chainrules.jl:221
...
```

Tests of this package are a bit of a disaster but I don't have time to dig into them.